### PR TITLE
fix(ci): enforce ubuntu-latest for scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ${{ fromJSON(vars.ACTIONS_RUNNER_LABELS || '["ubuntu-latest"]') }}
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       id-token: write


### PR DESCRIPTION
## Summary
- Enforce `runs-on: ubuntu-latest` for the Scorecard job to satisfy the Scorecard action workflow restriction.
- Ensures results publishing succeeds during the Scorecard workflow.

## Why
- The workflow previously used `vars.ACTIONS_RUNNER_LABELS`, which can expand to multiple labels or non-Ubuntu runners. The Scorecard action requires exactly one GitHub-hosted Ubuntu environment for the job that runs the action.

## Testing
- Not run (workflow change only).
