### PR TITLE
feat(projects): complete safe lifecycle management

### DIFF
--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -62,8 +62,39 @@ Project workspace root. Ownership is per authenticated app user.
 - `owner_user_id` (Neon Auth user id; required)
 - `name`
 - `slug`
-- `status`
+- `status` (`active`, `archived`, or `deleting`)
 - `created_at`, `updated_at`
+
+Project lifecycle mutations require an exact `owner_user_id` match. Archived
+projects retain their data and can be restored but cannot start new work.
+Deletion atomically claims the project as `deleting`; that state is non-writable,
+irreversible, and retryable. Cleanup removes every Blob under
+`projects/{projectId}/`, every Vector namespace under `project:{projectId}:`, and
+project retrieval-cache keys before the database cascade. The final Blob sweep
+cannot begin while a durable `project_upload_grants` row is unexpired, so a
+direct-upload capability issued before the deletion claim cannot create a late,
+untracked object. `infra_resources` and `deployments` intentionally retain their
+original `project_id` without a foreign key, so provider handles and non-secret
+provenance survive as detached operational tombstones. Project deletion does
+not decommission those external resources; operators use the retained records
+for later provider cleanup.
+
+### `project_upload_grants`
+
+Short-lived, signed Vercel Blob client-upload capabilities.
+
+- `id` (embedded in the signed completion payload)
+- `project_id`
+- `pathname`
+- `expires_at`
+- `completed_at` (nullable)
+- `created_at`
+
+Grant creation shares the active-project advisory lock. Completion marks an
+active-project grant settled; completion for an archived/deleting project
+deletes the Blob before removing the grant. Deletion remains retryable while a
+grant is live, prunes completed/expired grants, then performs a fresh prefix
+sweep before the relational cascade.
 
 ### `project_skills`
 
@@ -123,6 +154,9 @@ Records explicit user approvals for side-effectful actions.
 
 Stores non-secret resource identity + metadata.
 
+`project_id` is a durable provenance key rather than a foreign key, allowing the
+record to survive deletion of the owning app project.
+
 - `id`
 - `project_id`
 - `run_id` (optional; which run created/updated it)
@@ -134,6 +168,9 @@ Stores non-secret resource identity + metadata.
 - `created_at`, `updated_at`
 
 ### `deployments`
+
+`project_id` is a durable provenance key rather than a foreign key, allowing the
+record to survive deletion of the owning app project.
 
 - `id`
 - `project_id`

--- a/docs/architecture/repository-baseline.md
+++ b/docs/architecture/repository-baseline.md
@@ -1,7 +1,7 @@
-# Repository Baseline (Bootstrapped State)
+# Repository Baseline
 
-This document maps the **current** repository files to the architecture plan,
-so ADRs and SPECs remain grounded as the system is implemented.
+Current as of 2026-07-16. This document maps the released application to its
+architecture records so ADRs and SPECs stay grounded in implementation truth.
 
 ## Current directory structure
 
@@ -50,26 +50,52 @@ Why this matters:
   - Release Please: `.github/workflows/release-please.yml`
 - GitHub Dependabot is configured for the Bun ecosystem: `.github/dependabot.yml`.
 
-## Gaps between baseline and target system
+## Implemented product baseline
 
-The repo is intentionally bootstrapped: it includes core conventions, tooling,
-and some foundational modules, but does **not** yet include the full target
-system described in [docs/architecture/spec/index.md](./spec/index.md) and
-[docs/architecture/adr/index.md](./adr/index.md).
+The repository is a released AI SDK 7 application, not a scaffold. Its current
+product surface includes:
 
-Major gaps that remain:
+- project workspaces with exact-owner edit/archive/restore, active-work leases,
+  durable client-upload grants, and an irreversible, retry-safe deletion fence
+- project-scoped uploads, ingestion, retrieval, search, chat, and skills
+- durable research and implementation runs with approvals and streaming
+- Code Mode and Vercel Sandbox execution with persisted provenance
+- connected-repository indexing and RepoOps workflows
+- deterministic project and implementation audit-bundle exports
+- infrastructure/deployment records, webhook handlers, and preview governance
 
-- **Repo indexing (FR-032)** is implemented as a bounded, cost-guardrailed indexer
-  that reads tracked files from a sandbox checkout and upserts code chunks into
-  Upstash Vector under `project:{projectId}:repo:{repoId}`.
-  See [SPEC-0017](./spec/SPEC-0017-repo-ops-and-github-integration.md).
-- **Implementation audit bundle export (FR-034)** is implemented as a deterministic ZIP
-  uploaded to Vercel Blob and referenced by an artifact row. Project-wide deterministic
-  export remains available for latest artifacts + citations (`GET /api/export/:projectId`).
-  See [SPEC-0016](./spec/SPEC-0016-implementation-runs-end-to-end-build-and-deploy.md) and
-  [SPEC-0008](./spec/SPEC-0008-artifact-generation-versioning-and-export-zip.md).
-- Full artifact regeneration workflows remain partial; deterministic export endpoint is implemented (`GET /api/export/:projectId`).
-- Provider webhooks exist (GitHub/Vercel), but polling remains the default for external state.
+Detailed contracts and completion evidence remain in
+[the specification index](./spec/index.md). In particular:
 
-These are intentional: the repository is bootstrapped to keep initial complexity
-low, while the docs define the full production target.
+- [SPEC-0017](./spec/SPEC-0017-repo-ops-and-github-integration.md) defines the
+  bounded repository indexer and GitHub integration.
+- [SPEC-0016](./spec/SPEC-0016-implementation-runs-end-to-end-build-and-deploy.md)
+  and [SPEC-0008](./spec/SPEC-0008-artifact-generation-versioning-and-export-zip.md)
+  define deterministic implementation and project exports.
+- [SPEC-0020](./spec/SPEC-0020-project-workspace-and-search.md) defines project
+  lifecycle, workspace, and search behavior.
+
+## Remaining release gates
+
+- Keep public sign-up disabled until metered providers have a deliberate BYOK
+  or hosted-metering design (NFR-012).
+- Backfill historical `legacy-unowned` projects to a confirmed Neon Auth user,
+  verify zero sentinel-owned rows, then remove the compatibility read path.
+- Configure Vercel Blob and Upstash Redis/Vector in each environment before
+  enabling permanent deletion; the UI intentionally refuses relational-only
+  deletion when either cleanup provider is unavailable.
+- Run the full project lifecycle browser check against a configured preview
+  after database, Blob, Vector, Redis, and test-auth credentials are available:
+  create → rename → upload/search → archive/restore → typed deletion. The
+  repository does not track local credentials or a `.vercel` binding; never use
+  placeholder secrets to present this live preview check as complete. Keep
+  deterministic provider-contract and lifecycle-component tests in CI.
+- Persist run-level token/cost accounting and expose real consumption rather
+  than static budget limits (SPEC-0010).
+- Provider webhooks exist, but polling remains the default for external state.
+- Rotate the Neon API key used by the scheduled preview-drift audit, then rerun
+  audit-only mode before any cleanup mode.
+
+These gates do not justify compatibility shims or simulated success. Keep the
+deployment restricted and record missing manual configuration until each gate
+is completed and verified.

--- a/docs/architecture/spec/SPEC-0020-project-workspace-and-search.md
+++ b/docs/architecture/spec/SPEC-0020-project-workspace-and-search.md
@@ -1,11 +1,11 @@
 ---
 spec: SPEC-0020
 title: Project workspace and search UX
-version: 0.2.1
-date: 2026-02-06
+version: 0.3.2
+date: 2026-07-16
 owners: ["Bjorn Melin"]
 status: Implemented
-related_requirements: ["FR-002", "FR-019", "FR-020", "NFR-008", "IR-002", "IR-005"]
+related_requirements: ["FR-002", "FR-019", "FR-020", "NFR-007", "NFR-008", "IR-002", "IR-005"]
 related_adrs: ["ADR-0011", "ADR-0004", "ADR-0013", "ADR-0020"]
 notes:
   "Defines the user-facing workspace information architecture and search behavior."
@@ -76,6 +76,44 @@ Requirement IDs are defined in [docs/specs/requirements.md](/docs/specs/requirem
 - **IR-005:** Vector search via Upstash Vector (prefer HYBRID indexes when
   provisioning).
 
+### Project lifecycle
+
+- Project metadata mutations, archive/restore, and deletion require an exact
+  authenticated owner match. The temporary `legacy-unowned` read path is not a
+  mutation capability.
+- `active`, `archived`, and `deleting` are the supported project states.
+  Archiving is reversible, retains all project data, and prevents new work.
+  `deleting` is an irreversible, non-writable cleanup fence that remains
+  retryable until every owned external resource and relational row is gone.
+- Permanent deletion requires the project to be archived and the user to type
+  its exact slug.
+- Deletion is refused while a run or chat is pending/running/waiting/blocked,
+  while a sandbox job is pending/running/canceling, or while a job still owns
+  a sandbox that has not been stopped.
+- The archived-to-deleting transition uses a project-scoped Postgres advisory
+  lock. Resource producers acquire the same active-project lease for their
+  commit, so deletion either observes their durable work or rejects it after
+  claiming the fence. Queued ingestion, artifact, and skill-install work skips
+  commits for inactive projects.
+- `infra_resources` and `deployments` records survive project deletion as
+  detached operational tombstones. Deletion never decommissions live Neon,
+  Upstash, or Vercel resources, and the confirmation UI warns when retained
+  provider cleanup records exist.
+- The deletion order is every Vercel Blob object under the exact
+  `projects/{projectId}/` prefix, every Upstash Vector namespace under the exact
+  `project:{projectId}:` prefix, project-scoped Redis retrieval-cache entries,
+  then the project row. Database references are retained as a cleanup
+  cross-check, while prefix discovery covers unregistered uploads, orphaned
+  namespaces, and future resource kinds. The final database delete cascades to
+  project-owned relational rows.
+- Client upload tokens expire after five minutes. Their signed completion
+  callback shares the lifecycle lock and removes a completed Blob if deletion
+  already won the fence. Every token has a durable upload-grant row committed
+  before issuance. Deletion remains pending while a grant is unexpired, then
+  prunes settled grants and performs a fresh Blob prefix sweep before the
+  project cascade. A missed finite-retry callback therefore cannot leave a
+  permanent late-upload orphan.
+
 ## Constraints
 
 - Search must always respect access control boundaries:
@@ -135,6 +173,8 @@ Per project, provide consistent tabs:
 
 7. **Settings**
 
+   - name and slug editing
+   - archive, restore, and guarded permanent deletion
    - project settings and guardrail controls
 
 Search must support:
@@ -199,6 +239,12 @@ Accessibility and UX:
   navigation and ensures consistent deep-linkable URLs.
 - `src/app/(app)/projects/[projectId]/*/page.tsx`: tab pages (uploads/chat/runs/
   artifacts/implementation).
+- `src/app/(app)/projects/[projectId]/settings/actions.ts`: exact-owner project
+  metadata and lifecycle mutations.
+- `src/lib/projects/delete-project.server.ts`: retry-safe external cleanup and
+  final relational deletion orchestration.
+- `src/lib/projects/project-lifecycle-lease.server.ts`: canonical active-project
+  commit lease shared by work producers and the deletion claim.
 - `src/app/(app)/projects/[projectId]/artifacts/page.tsx`: list latest artifacts.
 - `src/app/(app)/projects/[projectId]/artifacts/[artifactId]/page.tsx`: artifact
   detail page (render markdown + citations + version links).
@@ -223,6 +269,11 @@ Accessibility and UX:
 ## Acceptance criteria
 
 - A user can create, open, edit, archive, and delete projects.
+- Archived projects remain readable and can be restored.
+- Permanent deletion requires typed confirmation, rejects active work, removes
+  every project-prefixed Blob and Vector namespace, purges retrieval caches, and
+  only then cascades project-owned relational records. Managed provider records
+  and cleanup handles remain detached for later decommissioning.
 - The project workspace has stable, deep-linkable tabs with consistent URL
   structure.
 - Global search returns scoped results across projects.
@@ -233,16 +284,25 @@ Accessibility and UX:
 
 ## Testing
 
-- Unit tests: result merging, ranking, and filter logic.
+- Unit tests: result merging, ranking, filter logic, exact-owner lifecycle
+  mutations, advisory-lock leases, deletion guards, prefix pagination, orphaned
+  resource discovery, and external-cleanup order.
 - Integration tests: search route handler enforces scoping and returns stable
   deep links.
-- E2E tests: create project → upload → search → navigate to result.
+- Required preview E2E release check: create project → rename → upload → search
+  → navigate → archive → restore → archive → typed-confirm deletion. Run it only
+  with configured database, Blob, Vector, Redis, and test-auth credentials; the
+  unconfigured local checkout must not substitute placeholder secrets or a
+  relational-only deletion path.
 
 ## Operational notes
 
 - Track search latency and error rates (see SPEC-0010).
 - Treat “missing provenance” (result without deep link) as a bug; it breaks
   traceability.
+- Keep deletion disabled when Blob or Vector credentials are unavailable. Do
+  not delete the relational row as a workaround; restore the integration and
+  retry instead.
 - When using IR-005 (Upstash Vector HYBRID indexes), upserts must include both
   dense and sparse vectors or the operation fails (see
   [Upstash Vector Hybrid Indexes](https://upstash.com/docs/vector/features/hybridindexes)).
@@ -276,3 +336,6 @@ Accessibility and UX:
 - **0.1.1 (2026-02-03)**: Linked to SPEC-0021 as the cross-cutting finalization spec.
 - **0.2.0 (2026-02-06)**: Implemented global search page, shared search UI patterns, and expanded `/api/search` contract (`scope/types/limit/cursor`) covering projects/uploads/chunks/artifacts/runs.
 - **0.2.1 (2026-02-06)**: Implemented ownership-scoped search enforcement, strict Zod query validation bounds, and server-side Upstash rate limiting for `/api/search`.
+- **0.3.0 (2026-07-16)**: Implemented exact-owner edit/archive/restore, typed-confirm deletion guards, Blob and Vector cleanup, cascading relational deletion, cache invalidation, and lifecycle UI/tests.
+- **0.3.1 (2026-07-16)**: Added the irreversible deletion fence, shared active-project leases, prefix-complete Blob/Vector discovery, Redis cache purge, detached provider-provenance tombstones, short-lived upload tokens, and retry-safe deletion UX.
+- **0.3.2 (2026-07-16)**: Added durable client-upload grants, deletion quiescence, and final prefix sweeping so finite Blob callback retries cannot orphan late uploads.

--- a/docs/ops/env.md
+++ b/docs/ops/env.md
@@ -136,12 +136,14 @@ App-level access control (cost control):
   ([Upstash Redis REST API](https://upstash.com/docs/redis/features/restapi))
 - `UPSTASH_REDIS_REST_TOKEN` (required for `env.upstash`)
   ([Upstash Redis REST API](https://upstash.com/docs/redis/features/restapi))
-  - Used by: caching, rate limiting, tool-call budgets.
+  - Used by: caching, rate limiting, tool-call budgets, and project retrieval
+    cache purge during permanent deletion.
 - `UPSTASH_VECTOR_REST_URL` (required for `env.upstash`)
   ([Upstash Vector REST API](https://upstash.com/docs/vector/features/metadata))
 - `UPSTASH_VECTOR_REST_TOKEN` (required for `env.upstash`)
   ([Upstash Vector REST API](https://upstash.com/docs/vector/features/metadata))
-  - Used by: semantic search index (uploads + artifacts).
+  - Used by: semantic search indexes and complete project-namespace cleanup
+    during permanent deletion.
 
 #### Redis client usage
 
@@ -207,7 +209,8 @@ export const POST = verifyQstashSignatureAppRouter(async (req) => {
 ### Vercel Blob
 
 - `BLOB_READ_WRITE_TOKEN` (required for `env.blob`)
-  - Token for reading/writing blobs (uploads)
+  - Token for reading/writing blobs (uploads) and prefix-complete project
+    deletion. Permanent deletion remains disabled when it is unavailable.
     ([Vercel Blob SDK](https://vercel.com/docs/storage/vercel-blob/using-blob-sdk)).
 
 ### Web research
@@ -297,7 +300,7 @@ Recommended Vector index settings:
 | `AI_GATEWAY_BASE_URL` | Required | Required | Required | Must use `https://ai-gateway.vercel.sh/v3/ai` |
 | `AI_GATEWAY_CHAT_MODEL` | Recommended | Recommended | Recommended | Default: `xai/grok-4.1-fast-reasoning` |
 | `AI_GATEWAY_EMBEDDING_MODEL` | Recommended | Recommended | Recommended | Default: `alibaba/qwen3-embedding-4b` |
-| `BLOB_READ_WRITE_TOKEN` | Required | Required | Required | Blob uploads |
+| `BLOB_READ_WRITE_TOKEN` | Required | Required | Required | Blob uploads, signed completion callbacks, and project deletion cleanup |
 | `EXA_API_KEY` | Required | Required | Required | Web research |
 | `FIRECRAWL_API_KEY` | Required | Required | Required | Web research |
 | `CONTEXT7_API_KEY` | Required | Required | Required | MCP/Context7 transport |

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "test:coverage": "bun run typegen && vitest run --coverage",
     "test:ci:merge": "mkdir -p .vitest-reports && vitest --merge-reports .vitest-reports/blob --reporter=github-actions --reporter=junit --outputFile.junit=.vitest-reports/junit.xml",
     "test:ci:shard": "bun run typegen && mkdir -p .vitest-reports/blob && vitest run --shard=$VITEST_SHARD_INDEX/$VITEST_SHARD_COUNT --reporter=blob --outputFile.blob=.vitest-reports/blob/$VITEST_SHARD_INDEX.json",
-    "test:a11y": "vitest run src/components/ai-elements/tests/accessibility.test.tsx src/components/ai-elements/tests/code-block.test.tsx src/components/ui/tests/command.test.tsx",
-    "test:a11y:watch": "vitest src/components/ai-elements/tests/accessibility.test.tsx src/components/ai-elements/tests/code-block.test.tsx src/components/ui/tests/command.test.tsx",
+    "test:a11y": "vitest run src/components/ai-elements/tests/accessibility.test.tsx src/components/ai-elements/tests/code-block.test.tsx src/components/ui/tests/command.test.tsx src/components/ui/confirm-dialog.test.tsx 'src/app/(app)/projects/[projectId]/settings/project-lifecycle-settings.test.tsx'",
+    "test:a11y:watch": "vitest src/components/ai-elements/tests/accessibility.test.tsx src/components/ai-elements/tests/code-block.test.tsx src/components/ui/tests/command.test.tsx src/components/ui/confirm-dialog.test.tsx 'src/app/(app)/projects/[projectId]/settings/project-lifecycle-settings.test.tsx'",
     "test:watch": "vitest",
     "typecheck": "bun run typegen && tsc -p tsconfig.json --noEmit",
     "typegen": "bun -e \"import { rmSync } from 'node:fs'; rmSync('.next/types', { recursive: true, force: true }); rmSync('.next/dev/types', { recursive: true, force: true });\" && bun --bun next typegen"

--- a/src/app/(app)/projects/[projectId]/project-layout-inner.tsx
+++ b/src/app/(app)/projects/[projectId]/project-layout-inner.tsx
@@ -35,7 +35,11 @@ export async function ProjectLayoutInner(
         <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
           <div className="space-y-1.5">
             <Badge className="rounded-full" variant="secondary">
-              Project Workspace
+              {project.status === "deleting"
+                ? "Deletion pending"
+                : project.status === "archived"
+                  ? "Archived workspace"
+                  : "Project workspace"}
             </Badge>
             <h1 className="font-semibold text-2xl tracking-tight md:text-3xl">
               {project.name}
@@ -50,6 +54,23 @@ export async function ProjectLayoutInner(
           </Link>
         </div>
       </header>
+
+      {project.status !== "active" ? (
+        <div
+          className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm"
+          role="status"
+        >
+          {project.status === "deleting"
+            ? "Deletion is pending. This workspace is read-only while cleanup remains retryable."
+            : "This workspace is archived and read-only. Restore it in Settings to start new work."}{" "}
+          <Link
+            className="font-medium underline underline-offset-4"
+            href={`/projects/${encodeURIComponent(project.id)}/settings`}
+          >
+            Open settings
+          </Link>
+        </div>
+      ) : null}
 
       <ProjectNavClient projectId={project.id} />
       <Separator />

--- a/src/app/(app)/projects/[projectId]/runs/run-controls-client.tsx
+++ b/src/app/(app)/projects/[projectId]/runs/run-controls-client.tsx
@@ -14,20 +14,38 @@ import { Button } from "@/components/ui/button";
  * @param props - Control props.
  * @returns Run control UI.
  */
-export function RunControlsClient(props: Readonly<{ projectId: string }>) {
+export function RunControlsClient(
+  props: Readonly<{
+    canStart: boolean;
+    projectId: string;
+    unavailableReason?: string;
+  }>,
+) {
   const [submittedKind, setSubmittedKind] = useState<string | null>(null);
   const [state, formAction, isPending] = useActionState(
     startRunAction,
     startRunInitialState,
   );
   const errorId = `runs-start-error-${props.projectId}`;
+  const unavailableReasonId = `runs-start-unavailable-${props.projectId}`;
 
   return (
     <form
       action={formAction}
-      aria-describedby={state.status === "error" ? errorId : undefined}
+      aria-describedby={
+        [
+          state.status === "error" ? errorId : null,
+          props.unavailableReason ? unavailableReasonId : null,
+        ]
+          .filter(Boolean)
+          .join(" ") || undefined
+      }
       className="space-y-3"
       onSubmit={(e) => {
+        if (!props.canStart) {
+          e.preventDefault();
+          return;
+        }
         const submitter = (e.nativeEvent as SubmitEvent)
           .submitter as HTMLButtonElement | null;
         setSubmittedKind(submitter?.getAttribute("value") ?? null);
@@ -44,7 +62,7 @@ export function RunControlsClient(props: Readonly<{ projectId: string }>) {
       <div className="flex flex-wrap items-center gap-2.5">
         <Button
           aria-busy={isPending && submittedKind === "research"}
-          disabled={isPending}
+          disabled={isPending || !props.canStart}
           name="kind"
           type="submit"
           value="research"
@@ -62,7 +80,7 @@ export function RunControlsClient(props: Readonly<{ projectId: string }>) {
 
         <Button
           aria-busy={isPending && submittedKind === "implementation"}
-          disabled={isPending}
+          disabled={isPending || !props.canStart}
           name="kind"
           type="submit"
           value="implementation"
@@ -82,6 +100,11 @@ export function RunControlsClient(props: Readonly<{ projectId: string }>) {
         <p className="text-muted-foreground text-sm">
           Runs are durable workflows backed by Workflow DevKit.
         </p>
+        {props.unavailableReason ? (
+          <p className="text-muted-foreground text-sm" id={unavailableReasonId}>
+            {props.unavailableReason}
+          </p>
+        ) : null}
       </div>
     </form>
   );

--- a/src/app/(app)/projects/[projectId]/runs/runs-content.tsx
+++ b/src/app/(app)/projects/[projectId]/runs/runs-content.tsx
@@ -44,6 +44,7 @@ export async function RunsContent(
   }
 
   const runs = await listRunsByProject(project.id, { limit: 50 });
+  const canStartRuns = project.status === "active";
 
   return (
     <Card>
@@ -51,7 +52,18 @@ export async function RunsContent(
         <CardTitle>Runs</CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
-        <RunControlsClient projectId={project.id} />
+        <RunControlsClient
+          canStart={canStartRuns}
+          projectId={project.id}
+          {...(!canStartRuns
+            ? {
+                unavailableReason:
+                  project.status === "deleting"
+                    ? "Deletion is pending; new runs are locked."
+                    : "Restore this project in Settings before starting a run.",
+              }
+            : {})}
+        />
 
         {runs.length === 0 ? (
           <Empty className="min-h-[180px] rounded-xl border">

--- a/src/app/(app)/projects/[projectId]/settings/actions.test.ts
+++ b/src/app/(app)/projects/[projectId]/settings/actions.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  projectCacheTags,
+  tagProject,
+  tagProjectsIndex,
+} from "@/lib/cache/tags";
+
+const state = vi.hoisted(() => ({
+  deleteProjectForUser: vi.fn(),
+  redirect: vi.fn(),
+  requireAppUser: vi.fn(),
+  setProjectStatusForUser: vi.fn(),
+  updateProjectForUser: vi.fn(),
+  updateTag: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ updateTag: state.updateTag }));
+vi.mock("next/navigation", () => ({ redirect: state.redirect }));
+vi.mock("@/lib/auth/require-app-user", () => ({
+  requireAppUser: state.requireAppUser,
+}));
+vi.mock("@/lib/data/projects.server", () => ({
+  setProjectStatusForUser: state.setProjectStatusForUser,
+  updateProjectForUser: state.updateProjectForUser,
+}));
+vi.mock("@/lib/projects/delete-project.server", () => ({
+  deleteProjectForUser: state.deleteProjectForUser,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.requireAppUser.mockResolvedValue({ id: "user_1" });
+  state.updateProjectForUser.mockResolvedValue({ id: "proj_1" });
+  state.setProjectStatusForUser.mockResolvedValue({ id: "proj_1" });
+  state.deleteProjectForUser.mockResolvedValue(undefined);
+});
+
+describe("project lifecycle actions", () => {
+  it("updates metadata and immediately refreshes project caches", async () => {
+    const { projectLifecycleInitialState, updateProjectAction } = await import(
+      "@/app/(app)/projects/[projectId]/settings/actions"
+    );
+    const data = new FormData();
+    data.set("projectId", "proj_1");
+    data.set("name", "Renamed");
+    data.set("slug", "renamed");
+
+    await expect(
+      updateProjectAction(projectLifecycleInitialState, data),
+    ).resolves.toEqual({
+      message: "Project details updated.",
+      status: "success",
+    });
+    expect(state.updateProjectForUser).toHaveBeenCalledWith({
+      name: "Renamed",
+      projectId: "proj_1",
+      slug: "renamed",
+      userId: "user_1",
+    });
+    expect(state.updateTag).toHaveBeenCalledWith(tagProject("proj_1"));
+    expect(state.updateTag).toHaveBeenCalledWith(tagProjectsIndex("user_1"));
+  });
+
+  it("archives and restores only recognized lifecycle states", async () => {
+    const { projectLifecycleInitialState, setProjectStatusAction } =
+      await import("@/app/(app)/projects/[projectId]/settings/actions");
+    const data = new FormData();
+    data.set("projectId", "proj_1");
+    data.set("status", "archived");
+    await expect(
+      setProjectStatusAction(projectLifecycleInitialState, data),
+    ).resolves.toEqual({ message: "Project archived.", status: "success" });
+
+    data.set("status", "deleting");
+    await expect(
+      setProjectStatusAction(projectLifecycleInitialState, data),
+    ).resolves.toEqual({ message: "Invalid project status.", status: "error" });
+  });
+
+  it("deletes with exact owner context, refreshes the index, and redirects", async () => {
+    const { deleteProjectAction } = await import(
+      "@/app/(app)/projects/[projectId]/settings/actions"
+    );
+    await deleteProjectAction({
+      confirmation: "project",
+      projectId: "proj_1",
+    });
+
+    expect(state.deleteProjectForUser).toHaveBeenCalledWith({
+      confirmation: "project",
+      projectId: "proj_1",
+      userId: "user_1",
+    });
+    expect(state.updateTag).toHaveBeenCalledWith(tagProjectsIndex("user_1"));
+    expect(state.redirect).toHaveBeenCalledWith("/projects");
+  });
+
+  it("returns deletion errors without redirecting", async () => {
+    state.deleteProjectForUser.mockRejectedValueOnce(
+      new Error("provider unavailable"),
+    );
+    const { deleteProjectAction } = await import(
+      "@/app/(app)/projects/[projectId]/settings/actions"
+    );
+    await expect(
+      deleteProjectAction({
+        confirmation: "project",
+        projectId: "proj_1",
+      }),
+    ).resolves.toEqual({ message: "Unexpected error.", status: "error" });
+    for (const tag of projectCacheTags("proj_1")) {
+      expect(state.updateTag).toHaveBeenCalledWith(tag);
+    }
+    expect(state.updateTag).toHaveBeenCalledWith(tagProjectsIndex("user_1"));
+    expect(state.redirect).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/(app)/projects/[projectId]/settings/actions.ts
+++ b/src/app/(app)/projects/[projectId]/settings/actions.ts
@@ -1,0 +1,135 @@
+"use server";
+
+import { updateTag } from "next/cache";
+import { redirect } from "next/navigation";
+
+import { requireAppUser } from "@/lib/auth/require-app-user";
+import {
+  projectCacheTags,
+  tagProject,
+  tagProjectsIndex,
+} from "@/lib/cache/tags";
+import { normalizeError } from "@/lib/core/errors";
+import {
+  setProjectStatusForUser,
+  updateProjectForUser,
+} from "@/lib/data/projects.server";
+import { deleteProjectForUser } from "@/lib/projects/delete-project.server";
+
+/** Result state shared by project lifecycle server actions. */
+export type ProjectLifecycleActionState =
+  | Readonly<{ status: "idle" }>
+  | Readonly<{ status: "success"; message: string }>
+  | Readonly<{ status: "error"; message: string }>;
+
+export const projectLifecycleInitialState: ProjectLifecycleActionState = {
+  status: "idle",
+};
+
+function readFormString(formData: FormData, key: string): string {
+  return String(formData.get(key) ?? "").trim();
+}
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    Boolean(err) &&
+    typeof err === "object" &&
+    (err as { code?: unknown }).code === "23505"
+  );
+}
+
+function refreshProjectCaches(projectId: string, userId: string): void {
+  updateTag(tagProject(projectId));
+  updateTag(tagProjectsIndex(userId));
+}
+
+/**
+ * Update project name and slug for the exact authenticated owner.
+ *
+ * @param _previous - Previous action state.
+ * @param formData - Submitted project metadata.
+ * @returns The mutation result for inline feedback.
+ */
+export async function updateProjectAction(
+  _previous: ProjectLifecycleActionState,
+  formData: FormData,
+): Promise<ProjectLifecycleActionState> {
+  const user = await requireAppUser();
+  const projectId = readFormString(formData, "projectId");
+
+  try {
+    await updateProjectForUser({
+      name: readFormString(formData, "name"),
+      projectId,
+      slug: readFormString(formData, "slug"),
+      userId: user.id,
+    });
+    refreshProjectCaches(projectId, user.id);
+    return { message: "Project details updated.", status: "success" };
+  } catch (err) {
+    if (isUniqueViolation(err)) {
+      return {
+        message: "That project slug is already in use.",
+        status: "error",
+      };
+    }
+    return { message: normalizeError(err).message, status: "error" };
+  }
+}
+
+/**
+ * Archive or restore a project for the exact authenticated owner.
+ *
+ * @param _previous - Previous action state.
+ * @param formData - Submitted project identity and target status.
+ * @returns The mutation result for inline feedback.
+ */
+export async function setProjectStatusAction(
+  _previous: ProjectLifecycleActionState,
+  formData: FormData,
+): Promise<ProjectLifecycleActionState> {
+  const user = await requireAppUser();
+  const projectId = readFormString(formData, "projectId");
+  const status = readFormString(formData, "status");
+  if (status !== "active" && status !== "archived") {
+    return { message: "Invalid project status.", status: "error" };
+  }
+
+  try {
+    await setProjectStatusForUser({ projectId, status, userId: user.id });
+    refreshProjectCaches(projectId, user.id);
+    return {
+      message:
+        status === "archived" ? "Project archived." : "Project restored.",
+      status: "success",
+    };
+  } catch (err) {
+    return { message: normalizeError(err).message, status: "error" };
+  }
+}
+
+/**
+ * Permanently delete an archived project after exact typed confirmation.
+ *
+ * @param input - Project identity and typed slug confirmation.
+ * @returns An error result, or redirects to the project index after success.
+ */
+export async function deleteProjectAction(
+  input: Readonly<{ confirmation: string; projectId: string }>,
+): Promise<ProjectLifecycleActionState> {
+  const user = await requireAppUser();
+
+  try {
+    await deleteProjectForUser({ ...input, userId: user.id });
+  } catch (err) {
+    return { message: normalizeError(err).message, status: "error" };
+  } finally {
+    // Claiming deletion changes the project to `deleting` before provider
+    // cleanup. Refresh every project surface even when cleanup remains
+    // retryable after a provider failure.
+    for (const tag of projectCacheTags(input.projectId)) updateTag(tag);
+    updateTag(tagProjectsIndex(user.id));
+  }
+
+  redirect("/projects");
+}

--- a/src/app/(app)/projects/[projectId]/settings/page.tsx
+++ b/src/app/(app)/projects/[projectId]/settings/page.tsx
@@ -1,5 +1,15 @@
+import { notFound } from "next/navigation";
+
+import { ProjectLifecycleSettings } from "@/app/(app)/projects/[projectId]/settings/project-lifecycle-settings";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { requireAppUser } from "@/lib/auth/require-app-user";
 import { budgets } from "@/lib/config/budgets.server";
+import { listDeploymentsByProject } from "@/lib/data/deployments.server";
+import { listInfraResourcesByProject } from "@/lib/data/infra-resources.server";
+import {
+  getOwnedProjectByIdForUser,
+  getProjectByIdForUser,
+} from "@/lib/data/projects.server";
 import { env } from "@/lib/env";
 
 type FeatureStatus =
@@ -20,92 +30,142 @@ function safeFeature(getter: () => unknown): FeatureStatus {
 /**
  * Settings tab displaying budgets and integration status.
  *
+ * @param props - Route parameters for the current project.
  * @returns The settings page.
  */
-export default function ProjectSettingsPage() {
+export default async function ProjectSettingsPage(
+  props: Readonly<{ params: Promise<{ projectId: string }> }>,
+) {
+  const { projectId } = await props.params;
+  const user = await requireAppUser();
+  const project = await getProjectByIdForUser(projectId, user.id);
+  if (!project) notFound();
+  const canManage = Boolean(
+    await getOwnedProjectByIdForUser(projectId, user.id),
+  );
+  const [deployments, infraResources] = canManage
+    ? await Promise.all([
+        listDeploymentsByProject(projectId),
+        listInfraResourcesByProject(projectId),
+      ])
+    : [[], []];
+
   const aiGateway = safeFeature(() => env.aiGateway);
   const upstash = safeFeature(() => env.upstash);
+  const blob = safeFeature(() => env.blob);
   const qstashPublish = safeFeature(() => env.qstashPublish);
   const qstashVerify = safeFeature(() => env.qstashVerify);
 
   const nf = new Intl.NumberFormat();
   return (
-    <div className="grid gap-4 md:grid-cols-2">
-      <Card>
-        <CardHeader>
-          <CardTitle>Budgets</CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm">
-          <dl className="grid gap-3">
-            <div>
-              <dt className="text-muted-foreground">Max vector topK</dt>
-              <dd className="font-medium">
-                {nf.format(budgets.maxVectorTopK)}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-muted-foreground">Max upload bytes</dt>
-              <dd className="font-medium">
-                {nf.format(budgets.maxUploadBytes)}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-muted-foreground">Max embed batch size</dt>
-              <dd className="font-medium">
-                {nf.format(budgets.maxEmbedBatchSize)}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-muted-foreground">Tool cache TTL (s)</dt>
-              <dd className="font-medium">
-                {nf.format(budgets.toolCacheTtlSeconds)}
-              </dd>
-            </div>
-          </dl>
-        </CardContent>
-      </Card>
+    <div className="flex flex-col gap-6">
+      <ProjectLifecycleSettings
+        canManage={canManage}
+        deletionReady={
+          canManage &&
+          blob.status === "configured" &&
+          upstash.status === "configured"
+        }
+        {...(!canManage
+          ? {
+              deletionUnavailableReason:
+                "This legacy project is read-only until ownership is backfilled.",
+            }
+          : blob.status !== "configured" || upstash.status !== "configured"
+            ? {
+                deletionUnavailableReason:
+                  "Configure Vercel Blob and Upstash Redis/Vector before permanent deletion.",
+              }
+            : {})}
+        project={project}
+        retainsManagedResources={
+          deployments.length > 0 || infraResources.length > 0
+        }
+      />
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Integrations</CardTitle>
-        </CardHeader>
-        <CardContent className="text-sm">
-          <ul className="grid gap-3">
-            <li>
-              <p className="font-medium">AI Gateway</p>
-              <p className="text-muted-foreground">
-                {aiGateway.status === "configured"
-                  ? "Configured"
-                  : aiGateway.message}
-              </p>
-            </li>
-            <li>
-              <p className="font-medium">Upstash (Redis + Vector)</p>
-              <p className="text-muted-foreground">
-                {upstash.status === "configured"
-                  ? "Configured"
-                  : upstash.message}
-              </p>
-            </li>
-            <li>
-              <p className="font-medium">QStash publish</p>
-              <p className="text-muted-foreground">
-                {qstashPublish.status === "configured"
-                  ? "Configured"
-                  : qstashPublish.message}
-              </p>
-            </li>
-            <li>
-              <p className="font-medium">QStash verify</p>
-              <p className="text-muted-foreground">
-                {qstashVerify.status === "configured"
-                  ? "Configured"
-                  : qstashVerify.message}
-              </p>
-            </li>
-          </ul>
-        </CardContent>
-      </Card>
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Budgets</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm">
+            <dl className="grid gap-3">
+              <div>
+                <dt className="text-muted-foreground">Max vector topK</dt>
+                <dd className="font-medium">
+                  {nf.format(budgets.maxVectorTopK)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">Max upload bytes</dt>
+                <dd className="font-medium">
+                  {nf.format(budgets.maxUploadBytes)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">Max embed batch size</dt>
+                <dd className="font-medium">
+                  {nf.format(budgets.maxEmbedBatchSize)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-muted-foreground">Tool cache TTL (s)</dt>
+                <dd className="font-medium">
+                  {nf.format(budgets.toolCacheTtlSeconds)}
+                </dd>
+              </div>
+            </dl>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Integrations</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm">
+            <ul className="grid gap-3">
+              <li>
+                <p className="font-medium">AI Gateway</p>
+                <p className="text-muted-foreground">
+                  {aiGateway.status === "configured"
+                    ? "Configured"
+                    : aiGateway.message}
+                </p>
+              </li>
+              <li>
+                <p className="font-medium">Upstash (Redis + Vector)</p>
+                <p className="text-muted-foreground">
+                  {upstash.status === "configured"
+                    ? "Configured"
+                    : upstash.message}
+                </p>
+              </li>
+              <li>
+                <p className="font-medium">Vercel Blob</p>
+                <p className="text-muted-foreground">
+                  {blob.status === "configured" ? "Configured" : blob.message}
+                </p>
+              </li>
+              <li>
+                <p className="font-medium">QStash publish</p>
+                <p className="text-muted-foreground">
+                  {qstashPublish.status === "configured"
+                    ? "Configured"
+                    : qstashPublish.message}
+                </p>
+              </li>
+              <li>
+                <p className="font-medium">QStash verify</p>
+                <p className="text-muted-foreground">
+                  {qstashVerify.status === "configured"
+                    ? "Configured"
+                    : qstashVerify.message}
+                </p>
+              </li>
+            </ul>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/projects/[projectId]/settings/project-lifecycle-settings.test.tsx
+++ b/src/app/(app)/projects/[projectId]/settings/project-lifecycle-settings.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ProjectDto } from "@/lib/data/projects.server";
+
+const state = vi.hoisted(() => ({
+  deleteProjectAction: vi.fn(),
+  setProjectStatusAction: vi.fn(),
+  updateProjectAction: vi.fn(),
+}));
+
+vi.mock("@/app/(app)/projects/[projectId]/settings/actions", () => ({
+  deleteProjectAction: state.deleteProjectAction,
+  projectLifecycleInitialState: { status: "idle" },
+  setProjectStatusAction: state.setProjectStatusAction,
+  updateProjectAction: state.updateProjectAction,
+}));
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: (props: { children: ReactNode; open: boolean }) =>
+    props.open ? <div>{props.children}</div> : null,
+  DialogContent: (props: { children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  DialogDescription: (props: { children: ReactNode }) => (
+    <p>{props.children}</p>
+  ),
+  DialogFooter: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogHeader: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogTitle: (props: { children: ReactNode }) => <h2>{props.children}</h2>,
+}));
+
+const baseProject = {
+  createdAt: new Date(0).toISOString(),
+  id: "proj_1",
+  name: "Project",
+  slug: "project",
+  status: "archived" as const,
+  updatedAt: new Date(0).toISOString(),
+} satisfies ProjectDto;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.deleteProjectAction.mockResolvedValue({
+    message: "Deleted.",
+    status: "success",
+  });
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+async function renderLifecycle(
+  overrides: Partial<{
+    deletionReady: boolean;
+    deletionUnavailableReason: string;
+    project: ProjectDto;
+    retainsManagedResources: boolean;
+  }> = {},
+) {
+  const { ProjectLifecycleSettings } = await import(
+    "@/app/(app)/projects/[projectId]/settings/project-lifecycle-settings"
+  );
+  await act(async () => {
+    root.render(
+      <ProjectLifecycleSettings
+        canManage
+        deletionReady={overrides.deletionReady ?? true}
+        project={overrides.project ?? baseProject}
+        retainsManagedResources={overrides.retainsManagedResources ?? false}
+        {...(overrides.deletionUnavailableReason
+          ? {
+              deletionUnavailableReason: overrides.deletionUnavailableReason,
+            }
+          : {})}
+      />,
+    );
+  });
+}
+
+function findButton(label: string): HTMLButtonElement {
+  const button = [...container.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === label,
+  );
+  if (!(button instanceof HTMLButtonElement)) {
+    throw new Error(`Missing button: ${label}`);
+  }
+  return button;
+}
+
+describe("ProjectLifecycleSettings", () => {
+  it("requires an exact slug before enabling permanent deletion", async () => {
+    await renderLifecycle();
+    await act(async () => findButton("Delete project").click());
+
+    const input = container.querySelector<HTMLInputElement>(
+      "#delete-project-confirmation",
+    );
+    if (!input) throw new Error("Missing confirmation input.");
+    const confirm = findButton("Delete permanently");
+    expect(confirm.disabled).toBe(true);
+
+    await act(async () => {
+      const setter = Object.getOwnPropertyDescriptor(
+        HTMLInputElement.prototype,
+        "value",
+      )?.set;
+      setter?.call(input, "project");
+      input.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    expect(confirm.disabled).toBe(false);
+    await act(async () => {
+      confirm
+        .closest("form")
+        ?.dispatchEvent(
+          new Event("submit", { bubbles: true, cancelable: true }),
+        );
+    });
+    expect(state.deleteProjectAction).toHaveBeenCalledWith({
+      confirmation: "project",
+      projectId: "proj_1",
+    });
+  });
+
+  it("keeps unavailable deletion reasons focusable and prevents opening", async () => {
+    await renderLifecycle({
+      deletionReady: false,
+      deletionUnavailableReason: "Configure cleanup providers.",
+    });
+    const button = findButton("Delete project");
+    expect(button.getAttribute("aria-disabled")).toBe("true");
+    expect(button.getAttribute("aria-describedby")).toBe(
+      "delete-project-reason",
+    );
+
+    await act(async () => button.click());
+    expect(container.querySelector("#delete-project-confirmation")).toBeNull();
+  });
+
+  it("renders deletion-pending state as locked and retryable", async () => {
+    await renderLifecycle({
+      project: { ...baseProject, status: "deleting" },
+      retainsManagedResources: true,
+    });
+
+    expect(findButton("Retry deletion")).toBeDefined();
+    expect(
+      container.querySelector<HTMLInputElement>("#project-name")?.disabled,
+    ).toBe(true);
+    expect(container.textContent).toContain(
+      "External Neon, Upstash, or Vercel resources are not decommissioned.",
+    );
+  });
+});

--- a/src/app/(app)/projects/[projectId]/settings/project-lifecycle-settings.tsx
+++ b/src/app/(app)/projects/[projectId]/settings/project-lifecycle-settings.tsx
@@ -1,0 +1,325 @@
+"use client";
+
+import { ArchiveRestoreIcon, ArchiveXIcon, Trash2Icon } from "lucide-react";
+import { useActionState, useState } from "react";
+
+import {
+  deleteProjectAction,
+  projectLifecycleInitialState,
+  setProjectStatusAction,
+  updateProjectAction,
+} from "@/app/(app)/projects/[projectId]/settings/actions";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { Input } from "@/components/ui/input";
+import type { ProjectDto } from "@/lib/data/projects.server";
+
+function ActionMessage(
+  props: Readonly<{
+    state: typeof projectLifecycleInitialState;
+    id: string;
+  }>,
+) {
+  if (props.state.status === "idle") return null;
+  return (
+    <p
+      className={
+        props.state.status === "error"
+          ? "text-destructive text-sm"
+          : "text-muted-foreground text-sm"
+      }
+      id={props.id}
+      role={props.state.status === "error" ? "alert" : "status"}
+    >
+      {props.state.message}
+    </p>
+  );
+}
+
+/**
+ * Project metadata, archive, restore, and guarded deletion controls.
+ *
+ * @param props - Current project state.
+ * @returns Project lifecycle settings UI.
+ */
+export function ProjectLifecycleSettings(
+  props: Readonly<{
+    canManage: boolean;
+    deletionReady: boolean;
+    deletionUnavailableReason?: string;
+    project: ProjectDto;
+    retainsManagedResources: boolean;
+  }>,
+) {
+  const { project } = props;
+  const [updateState, updateAction, isUpdating] = useActionState(
+    updateProjectAction,
+    projectLifecycleInitialState,
+  );
+  const [statusState, statusAction, isChangingStatus] = useActionState(
+    setProjectStatusAction,
+    projectLifecycleInitialState,
+  );
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [confirmation, setConfirmation] = useState("");
+  const [deleteError, setDeleteError] = useState<string>();
+  const isArchived = project.status === "archived";
+  const isDeleting = project.status === "deleting";
+  const canEdit = props.canManage && !isDeleting;
+  const canDelete =
+    props.canManage && props.deletionReady && (isArchived || isDeleting);
+  const deletionReason = !props.canManage
+    ? props.deletionUnavailableReason
+    : !isArchived && !isDeleting
+      ? "Archive the project before permanent deletion."
+      : props.deletionUnavailableReason;
+  const statusLabel = isDeleting
+    ? "Deletion pending"
+    : isArchived
+      ? "Archived"
+      : "Active";
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle>Project details</CardTitle>
+            <Badge variant={isArchived || isDeleting ? "outline" : "secondary"}>
+              {statusLabel}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <form
+            action={updateAction}
+            aria-describedby={
+              updateState.status === "idle"
+                ? undefined
+                : "project-update-message"
+            }
+            className="flex flex-col gap-4"
+          >
+            <input name="projectId" type="hidden" value={project.id} />
+            <div className="flex flex-col gap-2">
+              <label className="font-medium text-sm" htmlFor="project-name">
+                Name
+              </label>
+              <Input
+                defaultValue={project.name}
+                disabled={isUpdating || !canEdit}
+                id="project-name"
+                maxLength={256}
+                name="name"
+                required
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <label className="font-medium text-sm" htmlFor="project-slug">
+                Slug
+              </label>
+              <Input
+                autoCapitalize="none"
+                autoCorrect="off"
+                defaultValue={project.slug}
+                aria-describedby="project-slug-help"
+                disabled={isUpdating || !canEdit}
+                id="project-slug"
+                maxLength={128}
+                name="slug"
+                pattern="[a-z0-9]+(?:-[a-z0-9]+)*"
+                required
+                spellCheck={false}
+              />
+              <p
+                className="text-muted-foreground text-xs"
+                id="project-slug-help"
+              >
+                Lowercase letters, numbers, and single dashes.
+              </p>
+            </div>
+            <ActionMessage id="project-update-message" state={updateState} />
+            <Button
+              aria-busy={isUpdating || undefined}
+              className="self-start"
+              disabled={isUpdating || !canEdit}
+              type="submit"
+            >
+              {isUpdating ? "Saving…" : "Save changes"}
+            </Button>
+          </form>
+          {!props.canManage ? (
+            <p className="mt-4 text-muted-foreground text-sm" role="status">
+              This legacy project is read-only until ownership is backfilled.
+            </p>
+          ) : isDeleting ? (
+            <p className="mt-4 text-muted-foreground text-sm" role="status">
+              Deletion is pending. Project details are locked while cleanup is
+              retryable.
+            </p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Lifecycle</CardTitle>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-5">
+          <div className="flex flex-col gap-3">
+            <div className="space-y-1">
+              <p className="font-medium text-sm">
+                {isDeleting
+                  ? "Deletion pending"
+                  : isArchived
+                    ? "Restore project"
+                    : "Archive project"}
+              </p>
+              <p className="text-muted-foreground text-sm">
+                {isDeleting
+                  ? "This irreversible state cannot be restored. Retry cleanup below."
+                  : isArchived
+                    ? "Return this workspace to active status."
+                    : "Keep the workspace readable while preventing new work."}
+              </p>
+            </div>
+            <form
+              action={statusAction}
+              aria-describedby={
+                statusState.status === "idle"
+                  ? undefined
+                  : "project-status-message"
+              }
+            >
+              <input name="projectId" type="hidden" value={project.id} />
+              <input
+                name="status"
+                type="hidden"
+                value={isArchived ? "active" : "archived"}
+              />
+              <Button
+                aria-busy={isChangingStatus || undefined}
+                disabled={isChangingStatus || !canEdit}
+                type="submit"
+                variant="outline"
+              >
+                {isArchived ? (
+                  <ArchiveRestoreIcon aria-hidden="true" />
+                ) : (
+                  <ArchiveXIcon aria-hidden="true" />
+                )}
+                {isChangingStatus
+                  ? "Updating…"
+                  : isDeleting
+                    ? "Deletion pending"
+                    : isArchived
+                      ? "Restore project"
+                      : "Archive project"}
+              </Button>
+            </form>
+            <ActionMessage id="project-status-message" state={statusState} />
+          </div>
+
+          <div className="border-t pt-5">
+            <div className="flex flex-col gap-3">
+              <div className="space-y-1">
+                <p className="font-medium text-sm">Delete project</p>
+                <p className="text-muted-foreground text-sm">
+                  Permanently removes the database records, uploads, sandbox
+                  transcripts, and vector indexes owned by this project.
+                </p>
+                {props.retainsManagedResources ? (
+                  <p className="text-amber-700 text-sm dark:text-amber-300">
+                    External Neon, Upstash, or Vercel resources are not
+                    decommissioned. Their non-secret provider records remain as
+                    detached cleanup provenance after this project is deleted.
+                  </p>
+                ) : null}
+              </div>
+              <Button
+                aria-describedby={
+                  deletionReason ? "delete-project-reason" : undefined
+                }
+                aria-disabled={!canDelete}
+                className="self-start aria-disabled:pointer-events-none aria-disabled:opacity-50"
+                onClick={() => {
+                  if (!canDelete) return;
+                  setDeleteError(undefined);
+                  setDeleteOpen(true);
+                }}
+                type="button"
+                variant="destructive"
+              >
+                <Trash2Icon aria-hidden="true" />
+                {isDeleting ? "Retry deletion" : "Delete project"}
+              </Button>
+              {deletionReason ? (
+                <p
+                  className="text-muted-foreground text-xs"
+                  id="delete-project-reason"
+                >
+                  {deletionReason}
+                </p>
+              ) : null}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        confirmDisabled={confirmation !== project.slug}
+        confirmLabel={isDeleting ? "Retry deletion" : "Delete permanently"}
+        description={
+          props.retainsManagedResources
+            ? "This cannot be undone. External provider resources remain live; their records are retained for later cleanup."
+            : "This cannot be undone. Active runs, chats, or sandboxes must be finished first."
+        }
+        dialogError={deleteError}
+        onConfirm={async () => {
+          setDeleteError(undefined);
+          const result = await deleteProjectAction({
+            confirmation,
+            projectId: project.id,
+          });
+          if (result.status === "error") {
+            setDeleteError(result.message);
+            throw new Error(result.message);
+          }
+        }}
+        onOpenChange={(open) => {
+          setDeleteOpen(open);
+          if (!open) {
+            setConfirmation("");
+            setDeleteError(undefined);
+          }
+        }}
+        open={deleteOpen}
+        title={`Delete ${project.name}?`}
+      >
+        <div className="flex flex-col gap-2">
+          <label className="text-sm" htmlFor="delete-project-confirmation">
+            Type <strong>{project.slug}</strong> to confirm
+          </label>
+          <Input
+            aria-describedby="delete-project-confirmation-help"
+            autoCapitalize="none"
+            autoComplete="off"
+            autoCorrect="off"
+            id="delete-project-confirmation"
+            onChange={(event) => setConfirmation(event.target.value)}
+            spellCheck={false}
+            value={confirmation}
+          />
+          <p
+            className="text-muted-foreground text-xs"
+            id="delete-project-confirmation-help"
+          >
+            The value must match the project slug exactly.
+          </p>
+        </div>
+      </ConfirmDialog>
+    </div>
+  );
+}

--- a/src/app/(app)/projects/[projectId]/uploads/upload-client.tsx
+++ b/src/app/(app)/projects/[projectId]/uploads/upload-client.tsx
@@ -14,7 +14,13 @@ import { uploadProjectFilesFromFiles } from "@/lib/uploads/upload-files.client";
  * @param props - Upload props containing the destination `projectId`.
  * @returns The upload form.
  */
-export function UploadClient(props: Readonly<{ projectId: string }>) {
+export function UploadClient(
+  props: Readonly<{
+    canUpload: boolean;
+    projectId: string;
+    unavailableReason?: string;
+  }>,
+) {
   const router = useRouter();
   const [files, setFiles] = useState<FileList | null>(null);
   const [inputKey, setInputKey] = useState(0);
@@ -29,10 +35,13 @@ export function UploadClient(props: Readonly<{ projectId: string }>) {
   const fileInputId = "uploads-file-input";
   const statusMessageId = "uploads-status-message";
   const errorMessageId = "uploads-error-message";
+  const unavailableReasonId = "uploads-unavailable-reason";
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setError(null);
+
+    if (!props.canUpload) return;
 
     if (!files || files.length === 0) {
       setError("Select at least one file.");
@@ -75,11 +84,14 @@ export function UploadClient(props: Readonly<{ projectId: string }>) {
           aria-describedby={
             error
               ? `${fileHelpId} ${statusMessageId} ${errorMessageId}`
-              : `${fileHelpId} ${statusMessageId}`
+              : `${fileHelpId} ${statusMessageId}${
+                  props.unavailableReason ? ` ${unavailableReasonId}` : ""
+                }`
           }
           aria-invalid={status === "error"}
           id={fileInputId}
           key={inputKey}
+          disabled={!props.canUpload || status === "uploading"}
           multiple
           name="file"
           onChange={(e) => setFiles(e.currentTarget.files)}
@@ -95,6 +107,7 @@ export function UploadClient(props: Readonly<{ projectId: string }>) {
         <div className="flex items-center gap-2">
           <Switch
             checked={asyncIngest}
+            disabled={!props.canUpload || status === "uploading"}
             id={ingestToggleId}
             onCheckedChange={setAsyncIngest}
           />
@@ -106,7 +119,7 @@ export function UploadClient(props: Readonly<{ projectId: string }>) {
         <Button
           aria-busy={status === "uploading"}
           className="min-w-24"
-          disabled={status === "uploading"}
+          disabled={!props.canUpload || status === "uploading"}
           type="submit"
         >
           {status === "uploading" ? (
@@ -118,6 +131,12 @@ export function UploadClient(props: Readonly<{ projectId: string }>) {
           <span>Upload</span>
         </Button>
       </div>
+
+      {props.unavailableReason ? (
+        <p className="text-muted-foreground text-sm" id={unavailableReasonId}>
+          {props.unavailableReason}
+        </p>
+      ) : null}
 
       <output aria-live="polite" className="sr-only" id={statusMessageId}>
         {status === "uploading"

--- a/src/app/(app)/projects/[projectId]/uploads/uploads-content.tsx
+++ b/src/app/(app)/projects/[projectId]/uploads/uploads-content.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { notFound } from "next/navigation";
 
 import { UploadClient } from "@/app/(app)/projects/[projectId]/uploads/upload-client";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -8,7 +9,9 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@/components/ui/empty";
+import { requireAppUser } from "@/lib/auth/require-app-user";
 import { listProjectFiles } from "@/lib/data/files.server";
+import { getProjectByIdForUser } from "@/lib/data/projects.server";
 
 function formatBytes(
   bytes: number,
@@ -39,8 +42,13 @@ export async function UploadsContent(
   }>,
 ) {
   const { projectId } = props;
-
-  const files = await listProjectFiles(projectId, { limit: 50 });
+  const user = await requireAppUser();
+  const [project, files] = await Promise.all([
+    getProjectByIdForUser(projectId, user.id),
+    listProjectFiles(projectId, { limit: 50 }),
+  ]);
+  if (!project) notFound();
+  const canUpload = project.status === "active";
   const fileSizeFormatter = new Intl.NumberFormat(undefined, {
     maximumFractionDigits: 1,
     minimumFractionDigits: 1,
@@ -53,7 +61,18 @@ export async function UploadsContent(
           <CardTitle>Upload files</CardTitle>
         </CardHeader>
         <CardContent>
-          <UploadClient projectId={projectId} />
+          <UploadClient
+            canUpload={canUpload}
+            projectId={projectId}
+            {...(!canUpload
+              ? {
+                  unavailableReason:
+                    project.status === "deleting"
+                      ? "Deletion is pending; uploads are locked."
+                      : "Restore this project in Settings before uploading files.",
+                }
+              : {})}
+          />
         </CardContent>
       </Card>
 

--- a/src/app/(app)/projects/projects-content.tsx
+++ b/src/app/(app)/projects/projects-content.tsx
@@ -37,6 +37,7 @@ export async function ProjectsContent(
     id: project.id,
     name: project.name,
     slug: project.slug,
+    status: project.status,
   }));
 
   return (

--- a/src/app/(app)/projects/projects-list-client.tsx
+++ b/src/app/(app)/projects/projects-list-client.tsx
@@ -4,6 +4,9 @@ import { useWindowVirtualizer } from "@tanstack/react-virtual";
 import Link from "next/link";
 import { useSyncExternalStore } from "react";
 
+import { Badge } from "@/components/ui/badge";
+import type { ProjectStatus } from "@/lib/data/projects.server";
+
 /**
  * A single project row rendered in the projects list.
  */
@@ -11,6 +14,7 @@ export type ProjectListItem = Readonly<{
   id: string;
   name: string;
   slug: string | null;
+  status: ProjectStatus;
 }>;
 
 const ITEM_GAP_PX = 8; // matches `gap-2`
@@ -21,6 +25,12 @@ const useHydrated = () =>
     () => true,
     () => false,
   );
+
+function projectStatusLabel(status: ProjectStatus): string | null {
+  if (status === "archived") return "Archived";
+  if (status === "deleting") return "Deletion pending";
+  return null;
+}
 
 /**
  * Virtualized project list for the `/projects` page.
@@ -62,9 +72,16 @@ export function ProjectsListClient(
                   {project.slug ?? ""}
                 </p>
               </div>
-              <span className="text-muted-foreground text-sm transition-colors group-hover:text-foreground">
-                Open
-              </span>
+              <div className="flex items-center gap-2">
+                {projectStatusLabel(project.status) ? (
+                  <Badge variant="outline">
+                    {projectStatusLabel(project.status)}
+                  </Badge>
+                ) : null}
+                <span className="text-muted-foreground text-sm transition-colors group-hover:text-foreground">
+                  Open
+                </span>
+              </div>
             </Link>
           </li>
         ))}
@@ -100,9 +117,16 @@ export function ProjectsListClient(
                   {project.slug ?? ""}
                 </p>
               </div>
-              <span className="text-muted-foreground text-sm transition-colors group-hover:text-foreground">
-                Open
-              </span>
+              <div className="flex items-center gap-2">
+                {projectStatusLabel(project.status) ? (
+                  <Badge variant="outline">
+                    {projectStatusLabel(project.status)}
+                  </Badge>
+                ) : null}
+                <span className="text-muted-foreground text-sm transition-colors group-hover:text-foreground">
+                  Open
+                </span>
+              </div>
             </Link>
           </li>
         );

--- a/src/app/api/approvals/__tests__/route.test.ts
+++ b/src/app/api/approvals/__tests__/route.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/data/approvals.server", () => ({
 }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getActiveProjectByIdForUser: state.getProjectByIdForUser,
   getProjectByIdForUser: state.getProjectByIdForUser,
 }));
 

--- a/src/app/api/approvals/route.ts
+++ b/src/app/api/approvals/route.ts
@@ -7,7 +7,10 @@ import {
   getApprovalById,
   listPendingApprovals,
 } from "@/lib/data/approvals.server";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import {
+  getActiveProjectByIdForUser,
+  getProjectByIdForUser,
+} from "@/lib/data/projects.server";
 import { getRunById } from "@/lib/data/runs.server";
 import { parseJsonBody } from "@/lib/next/parse-json-body.server";
 import { jsonError, jsonOk } from "@/lib/next/responses";
@@ -85,7 +88,10 @@ export async function POST(req: Request) {
       throw new AppError("not_found", 404, "Approval not found.");
     }
 
-    const project = await getProjectByIdForUser(existing.projectId, user.id);
+    const project = await getActiveProjectByIdForUser(
+      existing.projectId,
+      user.id,
+    );
     if (!project) {
       throw new AppError("forbidden", 403, "Forbidden.");
     }

--- a/src/app/api/chat/[runId]/__tests__/route.test.ts
+++ b/src/app/api/chat/[runId]/__tests__/route.test.ts
@@ -21,6 +21,7 @@ vi.mock("@/lib/data/chat.server", () => ({
 }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getActiveProjectByIdForUser: state.getProjectByIdForUser,
   getProjectByIdForUser: state.getProjectByIdForUser,
 }));
 

--- a/src/app/api/chat/[runId]/route.ts
+++ b/src/app/api/chat/[runId]/route.ts
@@ -4,7 +4,10 @@ import { requireAppUserApi } from "@/lib/auth/require-app-user-api.server";
 import { AppError } from "@/lib/core/errors";
 import { getChatThreadByWorkflowRunId } from "@/lib/data/chat.server";
 import { inspectChatFollowUp } from "@/lib/data/chat-follow-up.server";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import {
+  getActiveProjectByIdForUser,
+  getProjectByIdForUser,
+} from "@/lib/data/projects.server";
 import { parseJsonBody } from "@/lib/next/parse-json-body.server";
 import { jsonError, jsonOk } from "@/lib/next/responses";
 import { allowedUploadMimeTypeSet } from "@/lib/uploads/allowed-mime-types";
@@ -115,7 +118,10 @@ export async function POST(
       throw new AppError("not_found", 404, "Chat session not found.");
     }
 
-    const project = await getProjectByIdForUser(thread.projectId, user.id);
+    const project = await getActiveProjectByIdForUser(
+      thread.projectId,
+      user.id,
+    );
     if (!project) {
       throw new AppError("forbidden", 403, "Forbidden.");
     }

--- a/src/app/api/chat/__tests__/route.test.ts
+++ b/src/app/api/chat/__tests__/route.test.ts
@@ -409,6 +409,7 @@ describe("POST /api/chat", () => {
       projectId: "proj_1",
       threadId,
       title: "follow up",
+      userId: "user",
     });
     expect(state.claimChatWorkflow).toHaveBeenCalledWith(threadId, "run_123");
   });

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -116,6 +116,7 @@ export async function POST(req: Request): Promise<Response> {
       projectId: parsed.projectId,
       threadId,
       title,
+      userId: user.id,
     });
     if (intent.workflowRunId) {
       return streamChatRun(threadId, intent.workflowRunId);

--- a/src/app/api/deployments/__tests__/route.test.ts
+++ b/src/app/api/deployments/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const state = vi.hoisted(() => ({
   createDeploymentRecord: vi.fn(),
   getProjectByIdForUser: vi.fn(),
+  leaseDb: {},
   listDeploymentsByProject: vi.fn(),
   requireAppUserApi: vi.fn(),
 }));
@@ -17,7 +18,15 @@ vi.mock("@/lib/data/deployments.server", () => ({
 }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getActiveProjectByIdForUser: state.getProjectByIdForUser,
   getProjectByIdForUser: state.getProjectByIdForUser,
+}));
+
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: async (
+    _input: unknown,
+    work: (db: unknown) => Promise<unknown>,
+  ) => await work(state.leaseDb),
 }));
 
 async function loadRoute() {
@@ -163,6 +172,7 @@ describe("POST /api/deployments", () => {
         runId: "run_1",
         status: "created",
       }),
+      state.leaseDb,
     );
     await expect(res.json()).resolves.toMatchObject({
       deployment: { id: "dep_1" },

--- a/src/app/api/deployments/route.ts
+++ b/src/app/api/deployments/route.ts
@@ -6,9 +6,13 @@ import {
   createDeploymentRecord,
   listDeploymentsByProject,
 } from "@/lib/data/deployments.server";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import {
+  getActiveProjectByIdForUser,
+  getProjectByIdForUser,
+} from "@/lib/data/projects.server";
 import { parseJsonBody } from "@/lib/next/parse-json-body.server";
 import { jsonCreated, jsonError, jsonOk } from "@/lib/next/responses";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 
 const listQuerySchema = z.strictObject({
   limit: z.coerce.number().int().min(1).max(500).optional(),
@@ -88,7 +92,7 @@ export async function POST(req: Request) {
     const bodyPromise = parseJsonBody(req, createBodySchema);
     const [user, body] = await Promise.all([authPromise, bodyPromise]);
 
-    const project = await getProjectByIdForUser(body.projectId, user.id);
+    const project = await getActiveProjectByIdForUser(body.projectId, user.id);
     if (!project) {
       throw new AppError("forbidden", 403, "Forbidden.");
     }
@@ -99,24 +103,31 @@ export async function POST(req: Request) {
       throw new AppError("bad_request", 400, "Invalid startedAt/endedAt.");
     }
 
-    const deployment = await createDeploymentRecord({
-      ...(body.deploymentUrl === undefined
-        ? {}
-        : { deploymentUrl: body.deploymentUrl }),
-      ...(endedAt === undefined ? {} : { endedAt }),
-      ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
-      projectId: project.id,
-      ...(body.provider === undefined ? {} : { provider: body.provider }),
-      ...(body.runId === undefined ? {} : { runId: body.runId }),
-      ...(startedAt === undefined ? {} : { startedAt }),
-      status: body.status,
-      ...(body.vercelDeploymentId === undefined
-        ? {}
-        : { vercelDeploymentId: body.vercelDeploymentId }),
-      ...(body.vercelProjectId === undefined
-        ? {}
-        : { vercelProjectId: body.vercelProjectId }),
-    });
+    const deployment = await withActiveProjectLease(
+      { projectId: project.id, userId: user.id },
+      (db) =>
+        createDeploymentRecord(
+          {
+            ...(body.deploymentUrl === undefined
+              ? {}
+              : { deploymentUrl: body.deploymentUrl }),
+            ...(endedAt === undefined ? {} : { endedAt }),
+            ...(body.metadata === undefined ? {} : { metadata: body.metadata }),
+            projectId: project.id,
+            ...(body.provider === undefined ? {} : { provider: body.provider }),
+            ...(body.runId === undefined ? {} : { runId: body.runId }),
+            ...(startedAt === undefined ? {} : { startedAt }),
+            status: body.status,
+            ...(body.vercelDeploymentId === undefined
+              ? {}
+              : { vercelDeploymentId: body.vercelDeploymentId }),
+            ...(body.vercelProjectId === undefined
+              ? {}
+              : { vercelProjectId: body.vercelProjectId }),
+          },
+          db,
+        ),
+    );
 
     return jsonCreated({ deployment });
   } catch (err) {

--- a/src/app/api/jobs/index-artifact/__tests__/route.test.ts
+++ b/src/app/api/jobs/index-artifact/__tests__/route.test.ts
@@ -91,4 +91,35 @@ describe("POST /api/jobs/index-artifact", () => {
     expect(state.indexArtifactVersion).toHaveBeenCalledTimes(1);
     expect(state.indexArtifactVersion).toHaveBeenCalledWith(payload);
   });
+
+  it.each([
+    "not_found",
+    "project_not_active",
+    "project_not_found",
+  ])("acknowledges a stale job after %s", async (code) => {
+    const POST = await loadRoute();
+    const { AppError } = await import("@/lib/core/errors");
+    state.indexArtifactVersion.mockRejectedValueOnce(
+      new AppError(code, code === "project_not_active" ? 409 : 404, "stale"),
+    );
+
+    const res = await POST(
+      new Request("http://localhost/api/jobs/index-artifact", {
+        body: JSON.stringify({
+          artifactId: "art_1",
+          kind: "PRD",
+          logicalKey: "PRD",
+          projectId: "proj_1",
+          version: 1,
+        }),
+        method: "POST",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      skipped: "project_inactive",
+    });
+  });
 });

--- a/src/app/api/jobs/index-artifact/route.ts
+++ b/src/app/api/jobs/index-artifact/route.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { indexArtifactVersion } from "@/lib/artifacts/index-artifact.server";
+import { AppError } from "@/lib/core/errors";
 import { parseJsonBody } from "@/lib/next/parse-json-body.server";
 import { jsonError, jsonOk } from "@/lib/next/responses";
 import { verifyQstashSignatureAppRouter } from "@/lib/upstash/qstash.server";
@@ -30,6 +31,14 @@ export const POST = verifyQstashSignatureAppRouter(async (req: Request) => {
     await indexArtifactVersion(parsed);
     return jsonOk({ ok: true });
   } catch (err) {
+    if (
+      err instanceof AppError &&
+      ["not_found", "project_not_active", "project_not_found"].includes(
+        err.code,
+      )
+    ) {
+      return jsonOk({ ok: true, skipped: "project_inactive" });
+    }
     return jsonError(err);
   }
 });

--- a/src/app/api/jobs/ingest-file/__tests__/route.test.ts
+++ b/src/app/api/jobs/ingest-file/__tests__/route.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
 import type { ProjectFileDto } from "@/lib/data/files.server";
 import type { IngestFileResult } from "@/lib/ingest/ingest-file.server";
 
@@ -111,7 +110,7 @@ describe("POST /api/jobs/ingest-file", () => {
     });
   });
 
-  it("rejects when the file is missing or mismatched", async () => {
+  it("acknowledges a stale job when the file was deleted", async () => {
     const POST = await loadRoute();
     state.getProjectFileById.mockResolvedValueOnce(null);
 
@@ -122,9 +121,10 @@ describe("POST /api/jobs/ingest-file", () => {
       }),
     );
 
-    expect(res.status).toBe(404);
-    await expect(res.json()).resolves.toMatchObject({
-      error: { code: "not_found" },
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      skipped: "project_inactive",
     });
   });
 
@@ -330,5 +330,39 @@ describe("POST /api/jobs/ingest-file", () => {
       expect.stringContaining(":uploads:index:"),
       "max",
     );
+  });
+
+  it.each([
+    "project_not_active",
+    "project_not_found",
+  ])("acknowledges a stale job after %s", async (code) => {
+    const POST = await loadRoute();
+    const { AppError } = await import("@/lib/core/errors");
+    const bytes = new Uint8Array([1, 2, 3]);
+    const crypto = await import("node:crypto");
+    const digest = crypto.createHash("sha256").update(bytes).digest("hex");
+    state.getProjectFileById.mockResolvedValueOnce({
+      ...baseFile,
+      sha256: digest,
+    });
+    globalThis.fetch = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(new Response(bytes, { status: 200 }));
+    state.ingestFile.mockRejectedValueOnce(
+      new AppError(code, code === "project_not_found" ? 404 : 409, "stale"),
+    );
+
+    const res = await POST(
+      new Request("http://localhost/api/jobs/ingest-file", {
+        body: JSON.stringify({ fileId, projectId }),
+        method: "POST",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      ok: true,
+      skipped: "project_inactive",
+    });
   });
 });

--- a/src/app/api/jobs/ingest-file/route.ts
+++ b/src/app/api/jobs/ingest-file/route.ts
@@ -77,6 +77,14 @@ export const POST = verifyQstashSignatureAppRouter(async (req: Request) => {
 
     return jsonOk(result);
   } catch (err) {
+    if (
+      err instanceof AppError &&
+      ["not_found", "project_not_active", "project_not_found"].includes(
+        err.code,
+      )
+    ) {
+      return jsonOk({ ok: true, skipped: "project_inactive" });
+    }
     return jsonError(err);
   }
 });

--- a/src/app/api/repos/__tests__/route.test.ts
+++ b/src/app/api/repos/__tests__/route.test.ts
@@ -4,6 +4,7 @@ const state = vi.hoisted(() => ({
   fetchGitHubRepoInfo: vi.fn(),
   getProjectByIdForUser: vi.fn(),
   isGitHubConfigured: vi.fn(),
+  leaseDb: {},
   listReposByProject: vi.fn(),
   requireAppUserApi: vi.fn(),
   upsertRepoConnection: vi.fn(),
@@ -14,6 +15,8 @@ vi.mock("@/lib/auth/require-app-user-api.server", () => ({
 }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getActiveProjectByIdForUser: (...args: unknown[]) =>
+    state.getProjectByIdForUser(...args),
   getProjectByIdForUser: (...args: unknown[]) =>
     state.getProjectByIdForUser(...args),
 }));
@@ -28,6 +31,13 @@ vi.mock("@/lib/repo/github.client.server", () => ({
   fetchGitHubRepoInfo: (...args: unknown[]) =>
     state.fetchGitHubRepoInfo(...args),
   isGitHubConfigured: (...args: unknown[]) => state.isGitHubConfigured(...args),
+}));
+
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: async (
+    _input: unknown,
+    work: (db: unknown) => Promise<unknown>,
+  ) => await work(state.leaseDb),
 }));
 
 async function loadRoute() {
@@ -156,6 +166,7 @@ describe("POST /api/repos", () => {
         defaultBranch: "main",
         htmlUrl: "https://example.com/repo",
       }),
+      state.leaseDb,
     );
   });
 });

--- a/src/app/api/repos/route.ts
+++ b/src/app/api/repos/route.ts
@@ -2,13 +2,17 @@ import { z } from "zod";
 
 import { requireAppUserApi } from "@/lib/auth/require-app-user-api.server";
 import { AppError } from "@/lib/core/errors";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import {
+  getActiveProjectByIdForUser,
+  getProjectByIdForUser,
+} from "@/lib/data/projects.server";
 import {
   listReposByProject,
   upsertRepoConnection,
 } from "@/lib/data/repos.server";
 import { parseJsonBody } from "@/lib/next/parse-json-body.server";
 import { jsonCreated, jsonError, jsonOk } from "@/lib/next/responses";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 import {
   fetchGitHubRepoInfo,
   isGitHubConfigured,
@@ -76,7 +80,7 @@ export async function POST(req: Request) {
     const bodyPromise = parseJsonBody(req, connectRepoSchema);
     const [user, body] = await Promise.all([authPromise, bodyPromise]);
 
-    const project = await getProjectByIdForUser(body.projectId, user.id);
+    const project = await getActiveProjectByIdForUser(body.projectId, user.id);
     if (!project) {
       throw new AppError("forbidden", 403, "Forbidden.");
     }
@@ -118,15 +122,22 @@ export async function POST(req: Request) {
       };
     }
 
-    const repo = await upsertRepoConnection({
-      cloneUrl: repoInfo.cloneUrl,
-      defaultBranch: repoInfo.defaultBranch,
-      htmlUrl: repoInfo.htmlUrl,
-      name: repoInfo.name,
-      owner: repoInfo.owner,
-      projectId: project.id,
-      provider: body.provider,
-    });
+    const repo = await withActiveProjectLease(
+      { projectId: project.id, userId: user.id },
+      (db) =>
+        upsertRepoConnection(
+          {
+            cloneUrl: repoInfo.cloneUrl,
+            defaultBranch: repoInfo.defaultBranch,
+            htmlUrl: repoInfo.htmlUrl,
+            name: repoInfo.name,
+            owner: repoInfo.owner,
+            projectId: project.id,
+            provider: body.provider,
+          },
+          db,
+        ),
+    );
 
     return jsonCreated({ repo });
   } catch (err) {

--- a/src/app/api/skills/__tests__/route.test.ts
+++ b/src/app/api/skills/__tests__/route.test.ts
@@ -4,8 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const state = vi.hoisted(() => ({
   del: vi.fn(),
   deleteProjectSkill: vi.fn(),
+  findProjectSkillByIdUncached: vi.fn(),
   getProjectByIdForUser: vi.fn(),
   getProjectSkillById: vi.fn(),
+  leaseDb: {},
   listProjectSkillsByProject: vi.fn(),
   requireAppUserApi: vi.fn(),
   upsertProjectSkill: vi.fn(),
@@ -20,17 +22,28 @@ vi.mock("@/lib/auth/require-app-user-api.server", () => ({
 }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getActiveProjectByIdForUser: (...args: unknown[]) =>
+    state.getProjectByIdForUser(...args),
   getProjectByIdForUser: (...args: unknown[]) =>
     state.getProjectByIdForUser(...args),
 }));
 
 vi.mock("@/lib/data/project-skills.server", () => ({
   deleteProjectSkill: (...args: unknown[]) => state.deleteProjectSkill(...args),
+  findProjectSkillByIdUncached: (...args: unknown[]) =>
+    state.findProjectSkillByIdUncached(...args),
   getProjectSkillById: (...args: unknown[]) =>
     state.getProjectSkillById(...args),
   listProjectSkillsByProject: (...args: unknown[]) =>
     state.listProjectSkillsByProject(...args),
   upsertProjectSkill: (...args: unknown[]) => state.upsertProjectSkill(...args),
+}));
+
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: async (
+    _input: unknown,
+    work: (db: unknown) => Promise<unknown>,
+  ) => await work(state.leaseDb),
 }));
 
 async function loadRoute() {
@@ -56,6 +69,7 @@ beforeEach(() => {
     updatedAt: new Date(0).toISOString(),
   });
   state.getProjectSkillById.mockResolvedValue(null);
+  state.findProjectSkillByIdUncached.mockResolvedValue(null);
   state.deleteProjectSkill.mockResolvedValue({ ok: true });
   state.del.mockResolvedValue(undefined);
 });
@@ -182,6 +196,7 @@ describe("POST /api/skills", () => {
         name: "My Skill",
         projectId: "proj_1",
       }),
+      state.leaseDb,
     );
   });
 });
@@ -220,16 +235,16 @@ describe("DELETE /api/skills", () => {
       }),
     );
     expect(res.status).toBe(200);
-    expect(state.deleteProjectSkill).toHaveBeenCalledWith({
-      projectId: "proj_1",
-      skillId: "skill_1",
-    });
+    expect(state.deleteProjectSkill).toHaveBeenCalledWith(
+      { projectId: "proj_1", skillId: "skill_1" },
+      state.leaseDb,
+    );
   });
 
   it("best-effort deletes the bundle blob when deleting a bundled skill", async () => {
     await withEnv({ BLOB_READ_WRITE_TOKEN: "rw_token" }, async () => {
       const { DELETE } = await loadRoute();
-      state.getProjectSkillById.mockResolvedValueOnce({
+      state.findProjectSkillByIdUncached.mockResolvedValueOnce({
         content: "---\nname: skills\ndescription: x\n---\n",
         createdAt: new Date(0).toISOString(),
         description: "x",

--- a/src/app/api/skills/registry/install/__tests__/route.test.ts
+++ b/src/app/api/skills/registry/install/__tests__/route.test.ts
@@ -14,6 +14,8 @@ vi.mock("@/lib/auth/require-app-user-api.server", () => ({
 }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getActiveProjectByIdForUser: (...args: unknown[]) =>
+    state.getProjectByIdForUser(...args),
   getProjectByIdForUser: (...args: unknown[]) =>
     state.getProjectByIdForUser(...args),
 }));

--- a/src/app/api/skills/registry/install/route.ts
+++ b/src/app/api/skills/registry/install/route.ts
@@ -5,7 +5,7 @@ import { requireAppUserApi } from "@/lib/auth/require-app-user-api.server";
 import { AppError } from "@/lib/core/errors";
 import { log } from "@/lib/core/log";
 import { recordProjectSkillRegistryInstall } from "@/lib/data/project-skill-registry-installs.server";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import { getActiveProjectByIdForUser } from "@/lib/data/projects.server";
 import { parseJsonBody } from "@/lib/next/parse-json-body.server";
 import { jsonError, jsonOk } from "@/lib/next/responses";
 import { installProjectSkillFromRegistry } from "@/workflows/skills-registry/project-skill-registry.workflow";
@@ -37,7 +37,7 @@ export async function POST(req: Request): Promise<Response> {
     projectId = body.projectId;
     registryId = body.registryId;
 
-    const project = await getProjectByIdForUser(body.projectId, user.id);
+    const project = await getActiveProjectByIdForUser(body.projectId, user.id);
     if (!project) {
       throw new AppError("forbidden", 403, "Forbidden.");
     }

--- a/src/app/api/skills/route.ts
+++ b/src/app/api/skills/route.ts
@@ -7,14 +7,19 @@ import { AppError } from "@/lib/core/errors";
 import { log } from "@/lib/core/log";
 import {
   deleteProjectSkill,
+  findProjectSkillByIdUncached,
   getProjectSkillById,
   listProjectSkillsByProject,
   upsertProjectSkill,
 } from "@/lib/data/project-skills.server";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import {
+  getActiveProjectByIdForUser,
+  getProjectByIdForUser,
+} from "@/lib/data/projects.server";
 import { env } from "@/lib/env";
 import { parseJsonBody } from "@/lib/next/parse-json-body.server";
 import { jsonCreated, jsonError, jsonOk } from "@/lib/next/responses";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 
 const listQuerySchema = z.strictObject({
   projectId: z.string().min(1),
@@ -134,7 +139,7 @@ export async function POST(req: Request) {
     projectId = body.projectId;
     skillName = body.name;
 
-    const project = await getProjectByIdForUser(body.projectId, user.id);
+    const project = await getActiveProjectByIdForUser(body.projectId, user.id);
     if (!project) {
       throw new AppError("forbidden", 403, "Forbidden.");
     }
@@ -144,16 +149,23 @@ export async function POST(req: Request) {
       userId: user.id,
     });
 
-    const skill = await upsertProjectSkill({
-      content: buildSkillMarkdown({
-        body: body.body,
-        description: body.description,
-        name: body.name,
-      }),
-      description: body.description,
-      name: body.name,
-      projectId: project.id,
-    });
+    const skill = await withActiveProjectLease(
+      { projectId: project.id, userId: user.id },
+      (db) =>
+        upsertProjectSkill(
+          {
+            content: buildSkillMarkdown({
+              body: body.body,
+              description: body.description,
+              name: body.name,
+            }),
+            description: body.description,
+            name: body.name,
+            projectId: project.id,
+          },
+          db,
+        ),
+    );
 
     const publicSkill = {
       content: skill.content,
@@ -202,7 +214,7 @@ export async function DELETE(req: Request) {
     projectId = body.projectId;
     skillId = body.skillId;
 
-    const project = await getProjectByIdForUser(body.projectId, user.id);
+    const project = await getActiveProjectByIdForUser(body.projectId, user.id);
     if (!project) {
       throw new AppError("forbidden", 403, "Forbidden.");
     }
@@ -213,24 +225,36 @@ export async function DELETE(req: Request) {
       userId: user.id,
     });
 
-    const skill = await getProjectSkillById(project.id, body.skillId);
-    if (skill) {
-      const bundle = getProjectSkillBundleRef(skill.metadata);
-      if (bundle?.blobPath) {
-        try {
-          await del(bundle.blobPath, { token: env.blob.readWriteToken });
-        } catch (error) {
-          // Best-effort cleanup: blob deletion failures should not block DB deletion.
-          log.error("project_skill_bundle_delete_failed", {
-            err: error,
-            projectId: project.id,
-            skillId: body.skillId,
-          });
+    await withActiveProjectLease(
+      { projectId: project.id, userId: user.id },
+      async (db) => {
+        const skill = await findProjectSkillByIdUncached(
+          project.id,
+          body.skillId,
+          db,
+        );
+        if (skill) {
+          const bundle = getProjectSkillBundleRef(skill.metadata);
+          if (bundle?.blobPath) {
+            try {
+              await del(bundle.blobPath, { token: env.blob.readWriteToken });
+            } catch (error) {
+              // Best-effort cleanup: blob deletion failures should not block DB deletion.
+              log.error("project_skill_bundle_delete_failed", {
+                err: error,
+                projectId: project.id,
+                skillId: body.skillId,
+              });
+            }
+          }
         }
-      }
-    }
 
-    await deleteProjectSkill({ projectId: project.id, skillId: body.skillId });
+        await deleteProjectSkill(
+          { projectId: project.id, skillId: body.skillId },
+          db,
+        );
+      },
+    );
     log.info("project_skill_delete_succeeded", {
       projectId: project.id,
       skillId: body.skillId,

--- a/src/app/api/upload/__tests__/route.test.ts
+++ b/src/app/api/upload/__tests__/route.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { ProjectDto } from "@/lib/data/projects.server";
-
 const state = vi.hoisted(() => ({
   budgets: {
     maxEmbedBatchSize: 64,
@@ -9,17 +7,22 @@ const state = vi.hoisted(() => ({
     maxVectorTopK: 12,
     toolCacheTtlSeconds: 600,
   },
+  del: vi.fn(),
   env: {
     blob: { readWriteToken: "blob-token" },
   },
-  getProjectByIdForUser: vi.fn(),
   handleUpload: vi.fn(),
+  issueProjectUploadGrant: vi.fn(),
+  removeRejectedProjectUploadGrant: vi.fn(),
   requireAppUserApi: vi.fn(),
+  resolveProjectUploadCompletion: vi.fn(),
 }));
 
 vi.mock("@vercel/blob/client", () => ({
   handleUpload: (...args: unknown[]) => state.handleUpload(...args),
 }));
+
+vi.mock("@vercel/blob", () => ({ del: state.del }));
 
 vi.mock("@/lib/auth/require-app-user-api.server", () => ({
   requireAppUserApi: state.requireAppUserApi,
@@ -29,8 +32,11 @@ vi.mock("@/lib/config/budgets.server", () => ({
   budgets: state.budgets,
 }));
 
-vi.mock("@/lib/data/projects.server", () => ({
-  getProjectByIdForUser: state.getProjectByIdForUser,
+vi.mock("@/lib/data/project-upload-grants.server", () => ({
+  issueProjectUploadGrant: state.issueProjectUploadGrant,
+  PROJECT_UPLOAD_GRANT_TTL_MS: 300_000,
+  removeRejectedProjectUploadGrant: state.removeRejectedProjectUploadGrant,
+  resolveProjectUploadCompletion: state.resolveProjectUploadCompletion,
 }));
 
 vi.mock("@/lib/env", () => ({
@@ -38,16 +44,7 @@ vi.mock("@/lib/env", () => ({
 }));
 
 const projectId = "proj_123";
-const now = new Date(0).toISOString();
-
-const baseProject = {
-  createdAt: now,
-  id: projectId,
-  name: "Project",
-  slug: "project",
-  status: "active",
-  updatedAt: now,
-} satisfies ProjectDto;
+const grantId = "11111111-1111-4111-8111-111111111111";
 
 function buildRequest(body: unknown): Request {
   return new Request("http://localhost/api/upload", {
@@ -69,6 +66,10 @@ type HandleUploadCall = {
     clientPayload: string | null,
     multipart: boolean,
   ) => Promise<Record<string, unknown>>;
+  onUploadCompleted?: (input: {
+    blob: { pathname: string; url: string };
+    tokenPayload?: string | null;
+  }) => Promise<void>;
 };
 
 function getOnBeforeGenerateToken(): HandleUploadCall["onBeforeGenerateToken"] {
@@ -78,16 +79,25 @@ function getOnBeforeGenerateToken(): HandleUploadCall["onBeforeGenerateToken"] {
   return call?.onBeforeGenerateToken;
 }
 
+function getOnUploadCompleted(): HandleUploadCall["onUploadCompleted"] {
+  const call = state.handleUpload.mock.calls[0]?.[0] as
+    | HandleUploadCall
+    | undefined;
+  return call?.onUploadCompleted;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 
   state.budgets.maxUploadBytes = 1024;
   state.requireAppUserApi.mockResolvedValue({ id: "user" });
-  state.getProjectByIdForUser.mockResolvedValue(baseProject);
   state.handleUpload.mockResolvedValue({
     clientToken: "vercel_blob_client_token",
     type: "blob.generate-client-token",
   });
+  state.issueProjectUploadGrant.mockResolvedValue({ id: grantId });
+  state.removeRejectedProjectUploadGrant.mockResolvedValue(undefined);
+  state.resolveProjectUploadCompletion.mockResolvedValue("keep");
 });
 
 describe("POST /api/upload", () => {
@@ -138,15 +148,87 @@ describe("POST /api/upload", () => {
       false,
     );
 
-    expect(state.getProjectByIdForUser).toHaveBeenCalledWith(projectId, "user");
+    expect(state.issueProjectUploadGrant).toHaveBeenCalledWith({
+      expiresAt: expect.any(Date),
+      pathname: `projects/${projectId}/uploads/alpha.txt`,
+      projectId,
+      userId: "user",
+    });
     expect(opts).toMatchObject({
       addRandomSuffix: true,
       allowOverwrite: false,
       maximumSizeInBytes: 1024,
+      tokenPayload: JSON.stringify({ grantId, projectId }),
     });
     expect(
       (opts as { allowedContentTypes?: unknown }).allowedContentTypes,
     ).toBeTruthy();
+  });
+
+  it("removes a completed upload when deletion won the lifecycle fence", async () => {
+    const POST = await loadRoute();
+    await POST(
+      buildRequest({
+        payload: {
+          clientPayload: JSON.stringify({ projectId }),
+          multipart: false,
+          pathname: `projects/${projectId}/uploads/alpha.txt`,
+        },
+        type: "blob.generate-client-token",
+      }),
+    );
+    state.resolveProjectUploadCompletion.mockResolvedValueOnce("delete");
+    const onUploadCompleted = getOnUploadCompleted();
+    if (!onUploadCompleted) throw new Error("Missing onUploadCompleted.");
+
+    await onUploadCompleted({
+      blob: {
+        pathname: `projects/${projectId}/uploads/alpha-random-suffix.txt`,
+        url: "https://store.blob.vercel-storage.com/projects/proj_123/uploads/alpha.txt",
+      },
+      tokenPayload: JSON.stringify({ grantId, projectId }),
+    });
+
+    expect(state.requireAppUserApi).not.toHaveBeenCalled();
+    expect(state.del).toHaveBeenCalledWith(
+      "https://store.blob.vercel-storage.com/projects/proj_123/uploads/alpha.txt",
+      { token: "blob-token" },
+    );
+    expect(state.removeRejectedProjectUploadGrant).toHaveBeenCalledWith({
+      grantId,
+      projectId,
+    });
+  });
+
+  it("settles an active upload grant without deleting its Blob", async () => {
+    const POST = await loadRoute();
+    await POST(
+      buildRequest({
+        payload: {
+          clientPayload: JSON.stringify({ projectId }),
+          multipart: false,
+          pathname: `projects/${projectId}/uploads/alpha.txt`,
+        },
+        type: "blob.generate-client-token",
+      }),
+    );
+    const onUploadCompleted = getOnUploadCompleted();
+    if (!onUploadCompleted) throw new Error("Missing onUploadCompleted.");
+
+    await onUploadCompleted({
+      blob: {
+        pathname: `projects/${projectId}/uploads/alpha-random-suffix.txt`,
+        url: "https://store.blob.vercel-storage.com/projects/proj_123/uploads/alpha.txt",
+      },
+      tokenPayload: JSON.stringify({ grantId, projectId }),
+    });
+
+    expect(state.resolveProjectUploadCompletion).toHaveBeenCalledWith({
+      grantId,
+      projectId,
+    });
+    expect(state.del).not.toHaveBeenCalled();
+    expect(state.removeRejectedProjectUploadGrant).not.toHaveBeenCalled();
   });
 
   it("rejects invalid clientPayload", async () => {

--- a/src/app/api/upload/register/__tests__/route.test.ts
+++ b/src/app/api/upload/register/__tests__/route.test.ts
@@ -30,6 +30,7 @@ const state = vi.hoisted(() => ({
   getProjectByIdForUser: vi.fn(),
   getProjectFileBySha256: vi.fn(),
   ingestFile: vi.fn(),
+  leaseDb: {},
   publishJSON: vi.fn(),
   requireAppUserApi: vi.fn(),
   revalidateTag: vi.fn(),
@@ -58,6 +59,7 @@ vi.mock("@/lib/data/files.server", () => ({
 }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getActiveProjectByIdForUser: state.getProjectByIdForUser,
   getProjectByIdForUser: state.getProjectByIdForUser,
 }));
 
@@ -67,6 +69,13 @@ vi.mock("@/lib/env", () => ({
 
 vi.mock("@/lib/ingest/ingest-file.server", () => ({
   ingestFile: state.ingestFile,
+}));
+
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: async (
+    _input: unknown,
+    work: (db: unknown) => Promise<unknown>,
+  ) => await work(state.leaseDb),
 }));
 
 vi.mock("@/lib/upstash/qstash.server", () => ({

--- a/src/app/api/upload/register/route.ts
+++ b/src/app/api/upload/register/route.ts
@@ -14,11 +14,12 @@ import {
   type ProjectFileDto,
   upsertProjectFile,
 } from "@/lib/data/files.server";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import { getActiveProjectByIdForUser } from "@/lib/data/projects.server";
 import { env } from "@/lib/env";
 import { ingestFile } from "@/lib/ingest/ingest-file.server";
 import { parseJsonBody } from "@/lib/next/parse-json-body.server";
 import { jsonError, jsonOk } from "@/lib/next/responses";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 import { allowedUploadMimeTypeSet } from "@/lib/uploads/allowed-mime-types";
 import { sanitizeFilename } from "@/lib/uploads/filename";
 import { parseTrustedProjectUploadBlobUrl } from "@/lib/uploads/trusted-blob-url.server";
@@ -159,7 +160,10 @@ export async function POST(
     const bodyPromise = parseJsonBody(req, bodySchema);
     const [user, parsed] = await Promise.all([authPromise, bodyPromise]);
 
-    const project = await getProjectByIdForUser(parsed.projectId, user.id);
+    const project = await getActiveProjectByIdForUser(
+      parsed.projectId,
+      user.id,
+    );
     if (!project) {
       throw new AppError("not_found", 404, "Project not found.");
     }
@@ -265,14 +269,21 @@ export async function POST(
 
         const safeName = sanitizeFilename(blob.originalName);
         didMutateFilesIndex = true;
-        const dbFile = await upsertProjectFile({
-          mimeType: contentType,
-          name: safeName,
-          projectId: parsed.projectId,
-          sha256,
-          sizeBytes: bytes.byteLength,
-          storageKey: blob.url,
-        });
+        const dbFile = await withActiveProjectLease(
+          { projectId: parsed.projectId, userId: user.id },
+          (db) =>
+            upsertProjectFile(
+              {
+                mimeType: contentType,
+                name: safeName,
+                projectId: parsed.projectId,
+                sha256,
+                sizeBytes: bytes.byteLength,
+                storageKey: blob.url,
+              },
+              db,
+            ),
+        );
 
         // Concurrency safety: if another task registered the same sha256 first,
         // ensure we return the canonical DB row and clean up our extra blob.

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,16 +1,25 @@
+import { del } from "@vercel/blob";
 import { type HandleUploadBody, handleUpload } from "@vercel/blob/client";
 import type { NextResponse } from "next/server";
 
 import { requireAppUserApi } from "@/lib/auth/require-app-user-api.server";
 import { budgets } from "@/lib/config/budgets.server";
 import { AppError, type JsonError } from "@/lib/core/errors";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import {
+  issueProjectUploadGrant,
+  PROJECT_UPLOAD_GRANT_TTL_MS,
+  removeRejectedProjectUploadGrant,
+  resolveProjectUploadCompletion,
+} from "@/lib/data/project-upload-grants.server";
 import { env } from "@/lib/env";
 import { jsonError, jsonOk } from "@/lib/next/responses";
 import { allowedUploadMimeTypes } from "@/lib/uploads/allowed-mime-types";
 import { assertValidProjectUploadPathname } from "@/lib/uploads/trusted-blob-url.server";
 
-function safeParseClientPayload(payload: string | null): { projectId: string } {
+function safeParseUploadPayload(payload: string | null): {
+  grantId: string | null;
+  projectId: string;
+} {
   if (!payload) {
     throw new AppError("bad_request", 400, "Missing upload payload.");
   }
@@ -27,7 +36,17 @@ function safeParseClientPayload(payload: string | null): { projectId: string } {
   if (typeof projectId !== "string" || projectId.trim().length === 0) {
     throw new AppError("bad_request", 400, "Missing projectId.");
   }
-  return { projectId: projectId.trim() };
+  const grantId = (value as Record<string, unknown>).grantId;
+  if (
+    grantId !== undefined &&
+    (typeof grantId !== "string" || grantId.trim().length === 0)
+  ) {
+    throw new AppError("bad_request", 400, "Invalid upload grant.");
+  }
+  return {
+    grantId: typeof grantId === "string" ? grantId.trim() : null,
+    projectId: projectId.trim(),
+  };
 }
 
 /**
@@ -49,9 +68,7 @@ export async function POST(
   >
 > {
   try {
-    const userPromise = requireAppUserApi();
-    const bodyPromise = req.json().catch(() => null);
-    const [user, body] = await Promise.all([userPromise, bodyPromise]);
+    const body: unknown = await req.json().catch(() => null);
 
     if (!body) {
       throw new AppError("bad_request", 400, "Invalid request body.");
@@ -60,21 +77,48 @@ export async function POST(
     const result = await handleUpload({
       body: body as HandleUploadBody,
       onBeforeGenerateToken: async (pathname, clientPayload) => {
-        const { projectId } = safeParseClientPayload(clientPayload);
+        // Blob completion callbacks are authenticated by handleUpload's signed
+        // payload, not by an end-user session. Resolve user auth only in the
+        // client-token branch that actually needs it.
+        const user = await requireAppUserApi();
+        const { projectId } = safeParseUploadPayload(clientPayload);
         assertValidProjectUploadPathname({ pathname, projectId });
-
-        const project = await getProjectByIdForUser(projectId, user.id);
-        if (!project) {
-          throw new AppError("not_found", 404, "Project not found.");
-        }
+        const validUntil = Date.now() + PROJECT_UPLOAD_GRANT_TTL_MS;
+        const grant = await issueProjectUploadGrant({
+          expiresAt: new Date(validUntil),
+          pathname,
+          projectId,
+          userId: user.id,
+        });
 
         return {
           addRandomSuffix: true,
           allowedContentTypes: [...allowedUploadMimeTypes],
           allowOverwrite: false,
           maximumSizeInBytes: budgets.maxUploadBytes,
-          tokenPayload: clientPayload,
+          tokenPayload: JSON.stringify({ grantId: grant.id, projectId }),
+          validUntil,
         };
+      },
+      onUploadCompleted: async ({ blob, tokenPayload }) => {
+        const { grantId, projectId } = safeParseUploadPayload(
+          tokenPayload ?? null,
+        );
+        if (!grantId) {
+          throw new AppError("bad_request", 400, "Missing upload grant.");
+        }
+        assertValidProjectUploadPathname({
+          pathname: blob.pathname,
+          projectId,
+        });
+        const disposition = await resolveProjectUploadCompletion({
+          grantId,
+          projectId,
+        });
+        if (disposition === "delete") {
+          await del(blob.url, { token: env.blob.readWriteToken });
+          await removeRejectedProjectUploadGrant({ grantId, projectId });
+        }
       },
       request: req,
       token: env.blob.readWriteToken,
@@ -84,8 +128,6 @@ export async function POST(
       return jsonOk({ clientToken: result.clientToken });
     }
 
-    // We don't register upload completion callbacks for these tokens, but handle
-    // the response defensively if one is received.
     return jsonOk({ response: "ok" as const });
   } catch (err) {
     return jsonError(err);

--- a/src/components/ui/confirm-dialog.test.tsx
+++ b/src/components/ui/confirm-dialog.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { act, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: (props: { children: ReactNode; open: boolean }) =>
+    props.open ? <div>{props.children}</div> : null,
+  DialogContent: (props: { children: ReactNode }) => (
+    <div>{props.children}</div>
+  ),
+  DialogDescription: (props: { children: ReactNode }) => (
+    <p>{props.children}</p>
+  ),
+  DialogFooter: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogHeader: (props: { children: ReactNode }) => <div>{props.children}</div>,
+  DialogTitle: (props: { children: ReactNode }) => <h2>{props.children}</h2>,
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("ConfirmDialog", () => {
+  it("submits its form from keyboard-equivalent form submission", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onOpenChange = vi.fn();
+    const { ConfirmDialog } = await import("@/components/ui/confirm-dialog");
+
+    await act(async () => {
+      root.render(
+        <ConfirmDialog
+          onConfirm={onConfirm}
+          onOpenChange={onOpenChange}
+          open
+          title="Delete project?"
+        >
+          <input aria-label="Confirmation" />
+        </ConfirmDialog>,
+      );
+    });
+
+    const form = container.querySelector("form");
+    expect(form).not.toBeNull();
+    await act(async () => {
+      form?.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(onConfirm).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("does not submit while exact confirmation is disabled", async () => {
+    const onConfirm = vi.fn();
+    const { ConfirmDialog } = await import("@/components/ui/confirm-dialog");
+
+    await act(async () => {
+      root.render(
+        <ConfirmDialog
+          confirmDisabled
+          onConfirm={onConfirm}
+          onOpenChange={vi.fn()}
+          open
+          title="Delete project?"
+        />,
+      );
+    });
+
+    const submit = container.querySelector<HTMLButtonElement>(
+      'button[type="submit"]',
+    );
+    expect(submit?.disabled).toBe(true);
+
+    await act(async () => {
+      container
+        .querySelector("form")
+        ?.dispatchEvent(
+          new Event("submit", { bubbles: true, cancelable: true }),
+        );
+    });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ComponentProps } from "react";
+import type { ComponentProps, ReactNode } from "react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -33,6 +33,8 @@ export type ConfirmDialogProps = Readonly<{
    * Optional description shown under the title.
    */
   description?: string;
+  /** Optional confirmation controls rendered between the description and error. */
+  children?: ReactNode;
   /**
    * Optional error message shown inside the dialog.
    *
@@ -84,6 +86,7 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
     onOpenChange,
     title,
     description,
+    children,
     dialogError,
     confirmLabel = "Confirm",
     cancelLabel = "Cancel",
@@ -111,48 +114,55 @@ export function ConfirmDialog(props: ConfirmDialogProps) {
           ) : null}
         </DialogHeader>
 
-        {dialogError ? (
-          <p className="text-destructive text-sm" role="alert">
-            {dialogError}
-          </p>
-        ) : null}
+        <form
+          className="contents"
+          onSubmit={async (event) => {
+            event.preventDefault();
+            if (!canConfirm) return;
+            setIsConfirming(true);
+            try {
+              await onConfirm();
+              onOpenChange(false);
+            } catch {
+              // Keep dialog open on failure.
+            } finally {
+              setIsConfirming(false);
+            }
+          }}
+        >
+          {children}
 
-        <DialogFooter>
-          <Button
-            disabled={isConfirming}
-            onClick={() => onOpenChange(false)}
-            type="button"
-            variant="outline"
-          >
-            {cancelLabel}
-          </Button>
-          <Button
-            aria-busy={isConfirming || undefined}
-            disabled={!canConfirm}
-            onClick={async () => {
-              if (!canConfirm) return;
-              setIsConfirming(true);
-              try {
-                await onConfirm();
-                onOpenChange(false);
-              } catch {
-                // Keep dialog open on failure.
-              } finally {
-                setIsConfirming(false);
-              }
-            }}
-            type="button"
-            variant={confirmVariant}
-          >
-            {isConfirming ? (
-              <span
-                aria-hidden="true"
-                className="mr-2 size-3 rounded-full border-2 border-current border-t-transparent motion-safe:animate-spin motion-reduce:animate-none"
-              />
-            ) : null}
-            {confirmLabel}
-          </Button>
-        </DialogFooter>
+          {dialogError ? (
+            <p className="text-destructive text-sm" role="alert">
+              {dialogError}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              disabled={isConfirming}
+              onClick={() => onOpenChange(false)}
+              type="button"
+              variant="outline"
+            >
+              {cancelLabel}
+            </Button>
+            <Button
+              aria-busy={isConfirming || undefined}
+              disabled={!canConfirm}
+              type="submit"
+              variant={confirmVariant}
+            >
+              {isConfirming ? (
+                <span
+                  aria-hidden="true"
+                  className="mr-2 size-3 rounded-full border-2 border-current border-t-transparent motion-safe:animate-spin motion-reduce:animate-none"
+                />
+              ) : null}
+              {confirmLabel}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   );

--- a/src/db/migrations/0012_short_frog_thor.sql
+++ b/src/db/migrations/0012_short_frog_thor.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "deployments" DROP CONSTRAINT "deployments_project_id_projects_id_fk";
+--> statement-breakpoint
+ALTER TABLE "infra_resources" DROP CONSTRAINT "infra_resources_project_id_projects_id_fk";

--- a/src/db/migrations/0013_equal_zeigeist.sql
+++ b/src/db/migrations/0013_equal_zeigeist.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "project_upload_grants" (
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"pathname" text NOT NULL,
+	"project_id" uuid NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "project_upload_grants" ADD CONSTRAINT "project_upload_grants_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "project_upload_grants_project_id_expires_at_idx" ON "project_upload_grants" USING btree ("project_id","expires_at");

--- a/src/db/migrations/meta/0012_snapshot.json
+++ b/src/db/migrations/meta/0012_snapshot.json
@@ -1,0 +1,2180 @@
+{
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "dialect": "postgresql",
+  "enums": {
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": ["neon", "upstash", "vercel"]
+    },
+    "public.repo_provider": {
+      "name": "repo_provider",
+      "schema": "public",
+      "values": ["github"]
+    },
+    "public.run_kind": {
+      "name": "run_kind",
+      "schema": "public",
+      "values": ["research", "implementation"]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "waiting",
+        "blocked",
+        "succeeded",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.run_step_kind": {
+      "name": "run_step_kind",
+      "schema": "public",
+      "values": ["llm", "tool", "sandbox", "wait", "approval", "external_poll"]
+    }
+  },
+  "id": "25a1aca9-88a3-46f9-b916-63e147dc05d8",
+  "policies": {},
+  "prevId": "3a08d3eb-8861-4ffc-b2a1-a3ce4c3cad33",
+  "roles": {},
+  "schemas": {},
+  "sequences": {},
+  "tables": {
+    "public.approvals": {
+      "checkConstraints": {},
+      "columns": {
+        "approved_at": {
+          "name": "approved_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "intent_summary": {
+          "name": "intent_summary",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "scope": {
+          "name": "scope",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "step_id": {
+          "name": "step_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "approvals_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "approvals_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "approvals",
+          "tableTo": "projects"
+        },
+        "approvals_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "approvals_run_id_runs_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "approvals",
+          "tableTo": "runs"
+        },
+        "approvals_step_id_run_steps_id_fk": {
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "name": "approvals_step_id_run_steps_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "approvals",
+          "tableTo": "run_steps"
+        }
+      },
+      "indexes": {
+        "approvals_run_id_scope_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "scope",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "approvals_run_id_scope_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "approvals",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.artifacts": {
+      "checkConstraints": {},
+      "columns": {
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(256)"
+        },
+        "kind": {
+          "name": "kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        },
+        "logical_key": {
+          "name": "logical_key",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(256)"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "version": {
+          "name": "version",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "artifacts_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "artifacts_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "artifacts",
+          "tableTo": "projects"
+        },
+        "artifacts_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "artifacts_run_id_runs_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "artifacts",
+          "tableTo": "runs"
+        }
+      },
+      "indexes": {
+        "artifacts_project_id_idempotency_key_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "artifacts_project_id_idempotency_key_unique",
+          "with": {}
+        },
+        "artifacts_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "artifacts_project_id_idx",
+          "with": {}
+        },
+        "artifacts_project_id_kind_key_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "kind",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "logical_key",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "artifacts_project_id_kind_key_idx",
+          "with": {}
+        },
+        "artifacts_project_id_kind_key_version_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "kind",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "logical_key",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "version",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "artifacts_project_id_kind_key_version_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "artifacts",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.chat_messages": {
+      "checkConstraints": {},
+      "columns": {
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "message_uid": {
+          "name": "message_uid",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "role": {
+          "name": "role",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(32)"
+        },
+        "text_content": {
+          "name": "text_content",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "ui_message": {
+          "name": "ui_message",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "jsonb"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "chat_messages_thread_id_chat_threads_id_fk": {
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
+          "name": "chat_messages_thread_id_chat_threads_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads"
+        }
+      },
+      "indexes": {
+        "chat_messages_thread_id_created_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "thread_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "created_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "chat_messages_thread_id_created_at_idx",
+          "with": {}
+        },
+        "chat_messages_thread_id_message_uid_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "thread_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "message_uid",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "chat_messages_thread_id_message_uid_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "chat_messages",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.chat_threads": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "last_activity_at": {
+          "default": "now()",
+          "name": "last_activity_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "mode": {
+          "default": "'chat-assistant'",
+          "name": "mode",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "status": {
+          "default": "'running'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_status",
+          "typeSchema": "public"
+        },
+        "title": {
+          "name": "title",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "chat_threads_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "chat_threads_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "chat_threads",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "chat_threads_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "chat_threads_project_id_idx",
+          "with": {}
+        },
+        "chat_threads_project_id_last_activity_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "chat_threads_project_id_last_activity_at_idx",
+          "with": {}
+        },
+        "chat_threads_project_id_status_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "status",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "chat_threads_project_id_status_idx",
+          "with": {}
+        },
+        "chat_threads_workflow_run_id_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "chat_threads_workflow_run_id_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "chat_threads",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.citations": {
+      "checkConstraints": {},
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "payload": {
+          "default": "'{}'::jsonb",
+          "name": "payload",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "source_type": {
+          "name": "source_type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "citations_artifact_id_artifacts_id_fk": {
+          "columnsFrom": ["artifact_id"],
+          "columnsTo": ["id"],
+          "name": "citations_artifact_id_artifacts_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "citations",
+          "tableTo": "artifacts"
+        },
+        "citations_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "citations_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "citations",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "citations_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "citations_project_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "citations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.deployments": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "deployment_url": {
+          "name": "deployment_url",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "provider": {
+          "default": "'vercel'",
+          "name": "provider",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "provider",
+          "typeSchema": "public"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "started_at": {
+          "name": "started_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "status": {
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "vercel_deployment_id": {
+          "name": "vercel_deployment_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "deployments_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "deployments_run_id_runs_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "deployments",
+          "tableTo": "runs"
+        }
+      },
+      "indexes": {
+        "deployments_project_id_status_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "status",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "deployments_project_id_status_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "deployments",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.file_chunks": {
+      "checkConstraints": {},
+      "columns": {
+        "chunk_index": {
+          "name": "chunk_index",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "file_id": {
+          "name": "file_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "page_end": {
+          "name": "page_end",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "page_start": {
+          "name": "page_start",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "token_count": {
+          "name": "token_count",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "integer"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "file_chunks_file_id_project_files_id_fk": {
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "name": "file_chunks_file_id_project_files_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "file_chunks",
+          "tableTo": "project_files"
+        },
+        "file_chunks_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "file_chunks_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "file_chunks",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "file_chunks_file_id_chunk_index_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "file_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "chunk_index",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "file_chunks_file_id_chunk_index_unique",
+          "with": {}
+        },
+        "file_chunks_project_id_file_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "file_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "file_chunks_project_id_file_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "file_chunks",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.infra_resources": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "external_id": {
+          "name": "external_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "provider": {
+          "name": "provider",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "provider",
+          "typeSchema": "public"
+        },
+        "region": {
+          "name": "region",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "infra_resources_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "infra_resources_run_id_runs_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "infra_resources",
+          "tableTo": "runs"
+        }
+      },
+      "indexes": {
+        "infra_resources_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "infra_resources_project_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "infra_resources",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.project_files": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "sha256": {
+          "name": "sha256",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "bigint"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "project_files_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "project_files_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "project_files",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "project_files_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_files_project_id_idx",
+          "with": {}
+        },
+        "project_files_project_id_sha256_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "sha256",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "project_files_project_id_sha256_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "project_files",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.project_skill_registry_installs": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "registry_id": {
+          "name": "registry_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "project_skill_registry_installs_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "project_skill_registry_installs_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "project_skill_registry_installs",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "project_skill_registry_installs_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_skill_registry_installs_project_id_idx",
+          "with": {}
+        },
+        "project_skill_registry_installs_workflow_run_id_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "project_skill_registry_installs_workflow_run_id_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "project_skill_registry_installs",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.project_skills": {
+      "checkConstraints": {},
+      "columns": {
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "description": {
+          "name": "description",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "name_norm": {
+          "name": "name_norm",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "project_skills_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "project_skills_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "project_skills",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "project_skills_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_skills_project_id_idx",
+          "with": {}
+        },
+        "project_skills_project_id_name_norm_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "name_norm",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "project_skills_project_id_name_norm_unique",
+          "with": {}
+        },
+        "project_skills_project_id_updated_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": false,
+              "expression": "updated_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_skills_project_id_updated_at_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "project_skills",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.projects": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "slug": {
+          "name": "slug",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "status": {
+          "default": "'active'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "projects_owner_user_id_slug_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "slug",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "projects_owner_user_id_slug_unique",
+          "with": {}
+        },
+        "projects_owner_user_id_updated_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": false,
+              "expression": "updated_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "projects_owner_user_id_updated_at_idx",
+          "with": {}
+        },
+        "projects_status_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "status",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "projects_status_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "projects",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.repos": {
+      "checkConstraints": {},
+      "columns": {
+        "clone_url": {
+          "name": "clone_url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "html_url": {
+          "name": "html_url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "owner": {
+          "name": "owner",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "provider": {
+          "name": "provider",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "repo_provider",
+          "typeSchema": "public"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "repos_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "repos_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "repos",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "repos_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "repos_project_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "repos",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.run_steps": {
+      "checkConstraints": {},
+      "columns": {
+        "attempt": {
+          "default": 0,
+          "name": "attempt",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "error": {
+          "name": "error",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "inputs": {
+          "default": "'{}'::jsonb",
+          "name": "inputs",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "outputs": {
+          "default": "'{}'::jsonb",
+          "name": "outputs",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "started_at": {
+          "name": "started_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "status": {
+          "default": "'pending'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_status",
+          "typeSchema": "public"
+        },
+        "step_id": {
+          "name": "step_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "step_kind": {
+          "name": "step_kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_step_kind",
+          "typeSchema": "public"
+        },
+        "step_name": {
+          "name": "step_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "run_steps_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "run_steps_run_id_runs_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "run_steps",
+          "tableTo": "runs"
+        }
+      },
+      "indexes": {
+        "run_steps_run_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "run_steps_run_id_idx",
+          "with": {}
+        },
+        "run_steps_run_id_step_id_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "step_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "run_steps_run_id_step_id_unique",
+          "with": {}
+        },
+        "run_steps_run_id_step_name_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "step_name",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "run_steps_run_id_step_name_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "run_steps",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.runs": {
+      "checkConstraints": {},
+      "columns": {
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "kind": {
+          "name": "kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_kind",
+          "typeSchema": "public"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "status": {
+          "default": "'pending'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_status",
+          "typeSchema": "public"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "runs_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "runs",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "runs_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "runs_project_id_idx",
+          "with": {}
+        },
+        "runs_workflow_run_id_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "runs_workflow_run_id_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "runs",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.sandbox_jobs": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "job_type": {
+          "name": "job_type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "provisioning_claimed_at": {
+          "name": "provisioning_claimed_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "provisioning_expires_at": {
+          "name": "provisioning_expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "provisioning_key": {
+          "name": "provisioning_key",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(256)"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "sandbox_stop_claimed_at": {
+          "name": "sandbox_stop_claimed_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "sandbox_stopped_at": {
+          "name": "sandbox_stopped_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "started_at": {
+          "name": "started_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "status": {
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(32)"
+        },
+        "step_id": {
+          "name": "step_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "transcript_blob_ref": {
+          "name": "transcript_blob_ref",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "sandbox_jobs_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "sandbox_jobs_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "sandbox_jobs",
+          "tableTo": "projects"
+        },
+        "sandbox_jobs_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "sandbox_jobs_run_id_runs_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "sandbox_jobs",
+          "tableTo": "runs"
+        },
+        "sandbox_jobs_step_id_run_steps_id_fk": {
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "name": "sandbox_jobs_step_id_run_steps_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "sandbox_jobs",
+          "tableTo": "run_steps"
+        }
+      },
+      "indexes": {
+        "sandbox_jobs_run_id_job_type_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "job_type",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "sandbox_jobs_run_id_job_type_idx",
+          "with": {}
+        },
+        "sandbox_jobs_run_id_provisioning_key_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "provisioning_key",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "sandbox_jobs_run_id_provisioning_key_unique",
+          "with": {}
+        },
+        "sandbox_jobs_run_id_sandbox_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "sandbox_jobs_run_id_sandbox_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "sandbox_jobs",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    }
+  },
+  "version": "7",
+  "views": {}
+}

--- a/src/db/migrations/meta/0013_snapshot.json
+++ b/src/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,2263 @@
+{
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "dialect": "postgresql",
+  "enums": {
+    "public.provider": {
+      "name": "provider",
+      "schema": "public",
+      "values": ["neon", "upstash", "vercel"]
+    },
+    "public.repo_provider": {
+      "name": "repo_provider",
+      "schema": "public",
+      "values": ["github"]
+    },
+    "public.run_kind": {
+      "name": "run_kind",
+      "schema": "public",
+      "values": ["research", "implementation"]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "waiting",
+        "blocked",
+        "succeeded",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.run_step_kind": {
+      "name": "run_step_kind",
+      "schema": "public",
+      "values": ["llm", "tool", "sandbox", "wait", "approval", "external_poll"]
+    }
+  },
+  "id": "e280b31d-2808-45e1-afee-47a00fe56ee6",
+  "policies": {},
+  "prevId": "25a1aca9-88a3-46f9-b916-63e147dc05d8",
+  "roles": {},
+  "schemas": {},
+  "sequences": {},
+  "tables": {
+    "public.approvals": {
+      "checkConstraints": {},
+      "columns": {
+        "approved_at": {
+          "name": "approved_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "approved_by": {
+          "name": "approved_by",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "intent_summary": {
+          "name": "intent_summary",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "scope": {
+          "name": "scope",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "step_id": {
+          "name": "step_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "approvals_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "approvals_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "approvals",
+          "tableTo": "projects"
+        },
+        "approvals_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "approvals_run_id_runs_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "approvals",
+          "tableTo": "runs"
+        },
+        "approvals_step_id_run_steps_id_fk": {
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "name": "approvals_step_id_run_steps_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "approvals",
+          "tableTo": "run_steps"
+        }
+      },
+      "indexes": {
+        "approvals_run_id_scope_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "scope",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "approvals_run_id_scope_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "approvals",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.artifacts": {
+      "checkConstraints": {},
+      "columns": {
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(256)"
+        },
+        "kind": {
+          "name": "kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        },
+        "logical_key": {
+          "name": "logical_key",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(256)"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "version": {
+          "name": "version",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "artifacts_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "artifacts_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "artifacts",
+          "tableTo": "projects"
+        },
+        "artifacts_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "artifacts_run_id_runs_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "artifacts",
+          "tableTo": "runs"
+        }
+      },
+      "indexes": {
+        "artifacts_project_id_idempotency_key_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "artifacts_project_id_idempotency_key_unique",
+          "with": {}
+        },
+        "artifacts_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "artifacts_project_id_idx",
+          "with": {}
+        },
+        "artifacts_project_id_kind_key_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "kind",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "logical_key",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "artifacts_project_id_kind_key_idx",
+          "with": {}
+        },
+        "artifacts_project_id_kind_key_version_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "kind",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "logical_key",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "version",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "artifacts_project_id_kind_key_version_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "artifacts",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.chat_messages": {
+      "checkConstraints": {},
+      "columns": {
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "message_uid": {
+          "name": "message_uid",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "role": {
+          "name": "role",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(32)"
+        },
+        "text_content": {
+          "name": "text_content",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "ui_message": {
+          "name": "ui_message",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "jsonb"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "chat_messages_thread_id_chat_threads_id_fk": {
+          "columnsFrom": ["thread_id"],
+          "columnsTo": ["id"],
+          "name": "chat_messages_thread_id_chat_threads_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "chat_messages",
+          "tableTo": "chat_threads"
+        }
+      },
+      "indexes": {
+        "chat_messages_thread_id_created_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "thread_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "created_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "chat_messages_thread_id_created_at_idx",
+          "with": {}
+        },
+        "chat_messages_thread_id_message_uid_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "thread_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "message_uid",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "chat_messages_thread_id_message_uid_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "chat_messages",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.chat_threads": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "last_activity_at": {
+          "default": "now()",
+          "name": "last_activity_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "mode": {
+          "default": "'chat-assistant'",
+          "name": "mode",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "status": {
+          "default": "'running'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_status",
+          "typeSchema": "public"
+        },
+        "title": {
+          "name": "title",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "chat_threads_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "chat_threads_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "chat_threads",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "chat_threads_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "chat_threads_project_id_idx",
+          "with": {}
+        },
+        "chat_threads_project_id_last_activity_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "last_activity_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "chat_threads_project_id_last_activity_at_idx",
+          "with": {}
+        },
+        "chat_threads_project_id_status_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "status",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "chat_threads_project_id_status_idx",
+          "with": {}
+        },
+        "chat_threads_workflow_run_id_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "chat_threads_workflow_run_id_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "chat_threads",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.citations": {
+      "checkConstraints": {},
+      "columns": {
+        "artifact_id": {
+          "name": "artifact_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "payload": {
+          "default": "'{}'::jsonb",
+          "name": "payload",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "source_type": {
+          "name": "source_type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "citations_artifact_id_artifacts_id_fk": {
+          "columnsFrom": ["artifact_id"],
+          "columnsTo": ["id"],
+          "name": "citations_artifact_id_artifacts_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "citations",
+          "tableTo": "artifacts"
+        },
+        "citations_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "citations_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "citations",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "citations_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "citations_project_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "citations",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.deployments": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "deployment_url": {
+          "name": "deployment_url",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "provider": {
+          "default": "'vercel'",
+          "name": "provider",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "provider",
+          "typeSchema": "public"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "started_at": {
+          "name": "started_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "status": {
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "vercel_deployment_id": {
+          "name": "vercel_deployment_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "vercel_project_id": {
+          "name": "vercel_project_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "deployments_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "deployments_run_id_runs_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "deployments",
+          "tableTo": "runs"
+        }
+      },
+      "indexes": {
+        "deployments_project_id_status_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "status",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "deployments_project_id_status_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "deployments",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.file_chunks": {
+      "checkConstraints": {},
+      "columns": {
+        "chunk_index": {
+          "name": "chunk_index",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "file_id": {
+          "name": "file_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "page_end": {
+          "name": "page_end",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "page_start": {
+          "name": "page_start",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "token_count": {
+          "name": "token_count",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "integer"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "file_chunks_file_id_project_files_id_fk": {
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "name": "file_chunks_file_id_project_files_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "file_chunks",
+          "tableTo": "project_files"
+        },
+        "file_chunks_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "file_chunks_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "file_chunks",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "file_chunks_file_id_chunk_index_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "file_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "chunk_index",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "file_chunks_file_id_chunk_index_unique",
+          "with": {}
+        },
+        "file_chunks_project_id_file_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "file_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "file_chunks_project_id_file_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "file_chunks",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.infra_resources": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "external_id": {
+          "name": "external_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "provider": {
+          "name": "provider",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "provider",
+          "typeSchema": "public"
+        },
+        "region": {
+          "name": "region",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "infra_resources_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "infra_resources_run_id_runs_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "infra_resources",
+          "tableTo": "runs"
+        }
+      },
+      "indexes": {
+        "infra_resources_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "infra_resources_project_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "infra_resources",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.project_files": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "sha256": {
+          "name": "sha256",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(64)"
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "bigint"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "project_files_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "project_files_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "project_files",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "project_files_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_files_project_id_idx",
+          "with": {}
+        },
+        "project_files_project_id_sha256_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "sha256",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "project_files_project_id_sha256_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "project_files",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.project_skill_registry_installs": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "registry_id": {
+          "name": "registry_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "project_skill_registry_installs_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "project_skill_registry_installs_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "project_skill_registry_installs",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "project_skill_registry_installs_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_skill_registry_installs_project_id_idx",
+          "with": {}
+        },
+        "project_skill_registry_installs_workflow_run_id_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "project_skill_registry_installs_workflow_run_id_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "project_skill_registry_installs",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.project_skills": {
+      "checkConstraints": {},
+      "columns": {
+        "content": {
+          "name": "content",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "description": {
+          "name": "description",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "name_norm": {
+          "name": "name_norm",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "project_skills_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "project_skills_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "project_skills",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "project_skills_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_skills_project_id_idx",
+          "with": {}
+        },
+        "project_skills_project_id_name_norm_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "name_norm",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "project_skills_project_id_name_norm_unique",
+          "with": {}
+        },
+        "project_skills_project_id_updated_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": false,
+              "expression": "updated_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_skills_project_id_updated_at_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "project_skills",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.project_upload_grants": {
+      "checkConstraints": {},
+      "columns": {
+        "completed_at": {
+          "name": "completed_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "pathname": {
+          "name": "pathname",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "project_upload_grants_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "project_upload_grants_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "project_upload_grants",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "project_upload_grants_project_id_expires_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "expires_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "project_upload_grants_project_id_expires_at_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "project_upload_grants",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.projects": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "owner_user_id": {
+          "name": "owner_user_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "slug": {
+          "name": "slug",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "status": {
+          "default": "'active'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {},
+      "indexes": {
+        "projects_owner_user_id_slug_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "slug",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "projects_owner_user_id_slug_unique",
+          "with": {}
+        },
+        "projects_owner_user_id_updated_at_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "owner_user_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": false,
+              "expression": "updated_at",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "projects_owner_user_id_updated_at_idx",
+          "with": {}
+        },
+        "projects_status_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "status",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "projects_status_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "projects",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.repos": {
+      "checkConstraints": {},
+      "columns": {
+        "clone_url": {
+          "name": "clone_url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "html_url": {
+          "name": "html_url",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "name": {
+          "name": "name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "owner": {
+          "name": "owner",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "provider": {
+          "name": "provider",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "repo_provider",
+          "typeSchema": "public"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "repos_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "repos_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "repos",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "repos_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "repos_project_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "repos",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.run_steps": {
+      "checkConstraints": {},
+      "columns": {
+        "attempt": {
+          "default": 0,
+          "name": "attempt",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "error": {
+          "name": "error",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "inputs": {
+          "default": "'{}'::jsonb",
+          "name": "inputs",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "outputs": {
+          "default": "'{}'::jsonb",
+          "name": "outputs",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "started_at": {
+          "name": "started_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "status": {
+          "default": "'pending'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_status",
+          "typeSchema": "public"
+        },
+        "step_id": {
+          "name": "step_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "step_kind": {
+          "name": "step_kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_step_kind",
+          "typeSchema": "public"
+        },
+        "step_name": {
+          "name": "step_name",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "run_steps_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "run_steps_run_id_runs_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "run_steps",
+          "tableTo": "runs"
+        }
+      },
+      "indexes": {
+        "run_steps_run_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "run_steps_run_id_idx",
+          "with": {}
+        },
+        "run_steps_run_id_step_id_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "step_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "run_steps_run_id_step_id_unique",
+          "with": {}
+        },
+        "run_steps_run_id_step_name_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "step_name",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "run_steps_run_id_step_name_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "run_steps",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.runs": {
+      "checkConstraints": {},
+      "columns": {
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "kind": {
+          "name": "kind",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_kind",
+          "typeSchema": "public"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "status": {
+          "default": "'pending'",
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "run_status",
+          "typeSchema": "public"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "workflow_run_id": {
+          "name": "workflow_run_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "runs_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "runs_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "runs",
+          "tableTo": "projects"
+        }
+      },
+      "indexes": {
+        "runs_project_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "project_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "runs_project_id_idx",
+          "with": {}
+        },
+        "runs_workflow_run_id_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "workflow_run_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "runs_workflow_run_id_unique",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "runs",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    },
+    "public.sandbox_jobs": {
+      "checkConstraints": {},
+      "columns": {
+        "created_at": {
+          "default": "now()",
+          "name": "created_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "integer"
+        },
+        "id": {
+          "default": "gen_random_uuid()",
+          "name": "id",
+          "notNull": true,
+          "primaryKey": true,
+          "type": "uuid"
+        },
+        "job_type": {
+          "name": "job_type",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "metadata": {
+          "default": "'{}'::jsonb",
+          "name": "metadata",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "jsonb"
+        },
+        "project_id": {
+          "name": "project_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "provisioning_claimed_at": {
+          "name": "provisioning_claimed_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "provisioning_expires_at": {
+          "name": "provisioning_expires_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "provisioning_key": {
+          "name": "provisioning_key",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(256)"
+        },
+        "run_id": {
+          "name": "run_id",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "sandbox_id": {
+          "name": "sandbox_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "varchar(128)"
+        },
+        "sandbox_stop_claimed_at": {
+          "name": "sandbox_stop_claimed_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "sandbox_stopped_at": {
+          "name": "sandbox_stopped_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "started_at": {
+          "name": "started_at",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        },
+        "status": {
+          "name": "status",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "varchar(32)"
+        },
+        "step_id": {
+          "name": "step_id",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "uuid"
+        },
+        "transcript_blob_ref": {
+          "name": "transcript_blob_ref",
+          "notNull": false,
+          "primaryKey": false,
+          "type": "text"
+        },
+        "updated_at": {
+          "default": "now()",
+          "name": "updated_at",
+          "notNull": true,
+          "primaryKey": false,
+          "type": "timestamp with time zone"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "foreignKeys": {
+        "sandbox_jobs_project_id_projects_id_fk": {
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "name": "sandbox_jobs_project_id_projects_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "sandbox_jobs",
+          "tableTo": "projects"
+        },
+        "sandbox_jobs_run_id_runs_id_fk": {
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "name": "sandbox_jobs_run_id_runs_id_fk",
+          "onDelete": "cascade",
+          "onUpdate": "no action",
+          "tableFrom": "sandbox_jobs",
+          "tableTo": "runs"
+        },
+        "sandbox_jobs_step_id_run_steps_id_fk": {
+          "columnsFrom": ["step_id"],
+          "columnsTo": ["id"],
+          "name": "sandbox_jobs_step_id_run_steps_id_fk",
+          "onDelete": "set null",
+          "onUpdate": "no action",
+          "tableFrom": "sandbox_jobs",
+          "tableTo": "run_steps"
+        }
+      },
+      "indexes": {
+        "sandbox_jobs_run_id_job_type_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "job_type",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "sandbox_jobs_run_id_job_type_idx",
+          "with": {}
+        },
+        "sandbox_jobs_run_id_provisioning_key_unique": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "provisioning_key",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": true,
+          "method": "btree",
+          "name": "sandbox_jobs_run_id_provisioning_key_unique",
+          "with": {}
+        },
+        "sandbox_jobs_run_id_sandbox_id_idx": {
+          "columns": [
+            {
+              "asc": true,
+              "expression": "run_id",
+              "isExpression": false,
+              "nulls": "last"
+            },
+            {
+              "asc": true,
+              "expression": "sandbox_id",
+              "isExpression": false,
+              "nulls": "last"
+            }
+          ],
+          "concurrently": false,
+          "isUnique": false,
+          "method": "btree",
+          "name": "sandbox_jobs_run_id_sandbox_id_idx",
+          "with": {}
+        }
+      },
+      "isRLSEnabled": false,
+      "name": "sandbox_jobs",
+      "policies": {},
+      "schema": "",
+      "uniqueConstraints": {}
+    }
+  },
+  "version": "7",
+  "views": {}
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -84,6 +84,20 @@
       "tag": "0011_backfill-code-mode-owner",
       "version": "7",
       "when": 1783945070534
+    },
+    {
+      "breakpoints": true,
+      "idx": 12,
+      "tag": "0012_short_frog_thor",
+      "version": "7",
+      "when": 1784214231344
+    },
+    {
+      "breakpoints": true,
+      "idx": 13,
+      "tag": "0013_equal_zeigeist",
+      "version": "7",
+      "when": 1784215837239
     }
   ],
   "version": "7"

--- a/src/db/migrations/project-upload-grants-migration.test.ts
+++ b/src/db/migrations/project-upload-grants-migration.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const migrationUrl = new URL("./0013_equal_zeigeist.sql", import.meta.url);
+
+describe("project upload grants migration", () => {
+  it("persists token expiry and cascades grants only with the final project delete", async () => {
+    const migration = await readFile(migrationUrl, "utf8");
+
+    expect(migration).toContain('CREATE TABLE "project_upload_grants"');
+    expect(migration).toContain(
+      '"expires_at" timestamp with time zone NOT NULL',
+    );
+    expect(migration).toContain(
+      'FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade',
+    );
+    expect(migration).toContain(
+      'CREATE INDEX "project_upload_grants_project_id_expires_at_idx"',
+    );
+  });
+});

--- a/src/db/migrations/provider-provenance-tombstone-migration.test.ts
+++ b/src/db/migrations/provider-provenance-tombstone-migration.test.ts
@@ -1,0 +1,20 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const migrationUrl = new URL("./0012_short_frog_thor.sql", import.meta.url);
+
+describe("provider provenance tombstone migration", () => {
+  it("preserves deployment and infrastructure records after project deletion", async () => {
+    const migration = await readFile(migrationUrl, "utf8");
+
+    expect(migration).toContain(
+      'ALTER TABLE "deployments" DROP CONSTRAINT "deployments_project_id_projects_id_fk"',
+    );
+    expect(migration).toContain(
+      'ALTER TABLE "infra_resources" DROP CONSTRAINT "infra_resources_project_id_projects_id_fk"',
+    );
+    expect(migration).not.toContain("project_files_project_id_projects_id_fk");
+    expect(migration).not.toContain("file_chunks_project_id_projects_id_fk");
+  });
+});

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -87,6 +87,35 @@ export const projectsTable = pgTable(
 );
 
 /**
+ * Short-lived Vercel Blob client-upload capabilities issued for a project.
+ *
+ * Deletion keeps the project tombstone until every grant has completed or
+ * expired, then performs its final prefix sweep. This prevents a client token
+ * issued before the deletion claim from creating an untracked late Blob.
+ */
+export const projectUploadGrantsTable = pgTable(
+  "project_upload_grants",
+  {
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    id: uuid("id").primaryKey().defaultRandom(),
+    pathname: text("pathname").notNull(),
+    projectId: uuid("project_id")
+      .notNull()
+      .references(() => projectsTable.id, { onDelete: "cascade" }),
+  },
+  (t) => [
+    index("project_upload_grants_project_id_expires_at_idx").on(
+      t.projectId,
+      t.expiresAt,
+    ),
+  ],
+);
+
+/**
  * Uploaded files belonging to a project (originals).
  */
 export const projectFilesTable = pgTable(
@@ -514,9 +543,9 @@ export const deploymentsTable = pgTable(
       .$type<Record<string, unknown>>()
       .notNull()
       .default({}),
-    projectId: uuid("project_id")
-      .notNull()
-      .references(() => projectsTable.id, { onDelete: "cascade" }),
+    // Intentionally not a foreign key: provider provenance survives project
+    // deletion as a detached operational tombstone for later decommissioning.
+    projectId: uuid("project_id").notNull(),
     provider: providerEnum("provider").notNull().default("vercel"),
     runId: uuid("run_id").references(() => runsTable.id, {
       onDelete: "set null",
@@ -547,9 +576,9 @@ export const infraResourcesTable = pgTable(
       .$type<Record<string, unknown>>()
       .notNull()
       .default({}),
-    projectId: uuid("project_id")
-      .notNull()
-      .references(() => projectsTable.id, { onDelete: "cascade" }),
+    // Intentionally not a foreign key: provider provenance survives project
+    // deletion as a detached operational tombstone for later decommissioning.
+    projectId: uuid("project_id").notNull(),
     provider: providerEnum("provider").notNull(),
     region: text("region"),
     resourceType: varchar("resource_type", { length: 128 }).notNull(),
@@ -629,7 +658,21 @@ export const projectsRelations = relations(projectsTable, ({ many }) => ({
   runs: many(runsTable),
   skillRegistryInstalls: many(projectSkillRegistryInstallsTable),
   skills: many(projectSkillsTable),
+  uploadGrants: many(projectUploadGrantsTable),
 }));
+
+/**
+ * Client-upload grant relations for Drizzle query helpers.
+ */
+export const projectUploadGrantsRelations = relations(
+  projectUploadGrantsTable,
+  ({ one }) => ({
+    project: one(projectsTable, {
+      fields: [projectUploadGrantsTable.projectId],
+      references: [projectsTable.id],
+    }),
+  }),
+);
 
 /**
  * Project file relations for Drizzle query helpers.

--- a/src/lib/ai/tools/retrieval.server.test.ts
+++ b/src/lib/ai/tools/retrieval.server.test.ts
@@ -11,6 +11,7 @@ const state = vi.hoisted(() => ({
   getRedis: vi.fn(),
   vectorNamespace: vi.fn(),
   vectorQuery: vi.fn(),
+  withActiveProjectLease: vi.fn(),
 }));
 
 vi.mock("@/lib/ai/embeddings.server", () => ({
@@ -28,6 +29,10 @@ vi.mock("@/lib/upstash/vector.server", () => ({
   projectChunksNamespace: (projectId: string) => `project:${projectId}:chunks`,
 }));
 
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: state.withActiveProjectLease,
+}));
+
 async function loadModule() {
   vi.resetModules();
   return import("@/lib/ai/tools/retrieval.server");
@@ -39,6 +44,9 @@ beforeEach(() => {
   state.embedText.mockResolvedValue([0.1, 0.2, 0.3]);
   state.vectorQuery.mockResolvedValue([]);
   state.vectorNamespace.mockReturnValue({ query: state.vectorQuery });
+  state.withActiveProjectLease.mockImplementation(
+    async (_input: unknown, work: () => Promise<unknown>) => await work(),
+  );
 
   state.getRedis.mockImplementation(() => {
     throw new Error("Redis not configured");
@@ -141,6 +149,47 @@ describe("retrieveProjectChunks", () => {
       },
     ]);
     expect(redis.setex).toHaveBeenCalled();
+    expect(state.withActiveProjectLease).toHaveBeenCalledWith(
+      { projectId },
+      expect.any(Function),
+    );
+  });
+
+  it("does not repopulate deleted project snippets when deletion wins the lifecycle lock", async () => {
+    const redis = {
+      get: vi.fn(async () => null),
+      setex: vi.fn(async () => {}),
+    };
+    state.getRedis.mockReturnValueOnce(redis);
+    state.withActiveProjectLease.mockRejectedValueOnce(
+      Object.assign(new Error("Project is deleting."), {
+        code: "project_not_active",
+        status: 409,
+      }),
+    );
+
+    const projectId = "11111111-1111-4111-8111-111111111111";
+    state.vectorQuery.mockResolvedValueOnce([
+      {
+        id: "hit_1",
+        metadata: {
+          chunkIndex: 1,
+          fileId: "file_1",
+          projectId,
+          snippet: "must not be cached",
+          type: "chunk",
+        },
+        score: 0.99,
+      },
+    ] satisfies readonly VectorQueryResult[]);
+
+    const { retrieveProjectChunks } = await loadModule();
+    await expect(
+      retrieveProjectChunks({ projectId, q: "hi", topK: 2 }),
+    ).resolves.toHaveLength(1);
+
+    expect(state.withActiveProjectLease).toHaveBeenCalledOnce();
+    expect(redis.setex).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/ai/tools/retrieval.server.ts
+++ b/src/lib/ai/tools/retrieval.server.ts
@@ -4,6 +4,7 @@ import { embedText } from "@/lib/ai/embeddings.server";
 import { budgets } from "@/lib/config/budgets.server";
 import { AppError } from "@/lib/core/errors";
 import { sha256Hex } from "@/lib/core/sha256";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 import { getRedis } from "@/lib/upstash/redis.server";
 import {
   getVectorIndex,
@@ -66,7 +67,7 @@ function cacheKey(
     q: input.q.trim().toLowerCase(),
     topK: input.topK,
   });
-  return `cache:retrieval:${sha256Hex(payload)}`;
+  return `cache:retrieval:project:${input.projectId}:chunks:${sha256Hex(payload)}`;
 }
 
 function cacheKeyArtifacts(
@@ -78,7 +79,52 @@ function cacheKeyArtifacts(
     topK: input.topK,
     type: "artifact",
   });
-  return `cache:retrieval:artifacts:${sha256Hex(payload)}`;
+  return `cache:retrieval:project:${input.projectId}:artifacts:${sha256Hex(payload)}`;
+}
+
+async function writeProjectRetrievalCache(
+  input: Readonly<{
+    key: string;
+    projectId: string;
+    redis: ReturnType<typeof getRedis>;
+    value: readonly ArtifactRetrievalHit[] | readonly RetrievalHit[];
+  }>,
+): Promise<void> {
+  // The project lease is the final-write fence shared with deletion. If this
+  // write wins the lock, deletion purges it afterwards; if deletion wins, the
+  // inactive project check prevents deleted snippets from being repopulated.
+  // Retrieval caching remains best-effort, so lifecycle/Redis failures never
+  // turn a successful vector query into a failed user request.
+  await withActiveProjectLease({ projectId: input.projectId }, async () => {
+    await input.redis.setex(
+      input.key,
+      budgets.toolCacheTtlSeconds,
+      input.value,
+    );
+  }).catch(() => {
+    // Silently ignore cache write failures.
+  });
+}
+
+/**
+ * Remove every Redis retrieval-cache entry owned by a project.
+ *
+ * @param projectId - Project whose retrieval keys must be removed.
+ */
+export async function purgeProjectRetrievalCache(
+  projectId: string,
+): Promise<void> {
+  const redis = getRedis();
+  const pattern = `cache:retrieval:project:${projectId}:*`;
+  let cursor = "0";
+  do {
+    const [nextCursor, keys] = await redis.scan(cursor, {
+      count: 200,
+      match: pattern,
+    });
+    if (keys.length > 0) await redis.del(...keys);
+    cursor = nextCursor;
+  } while (cursor !== "0");
 }
 
 /**
@@ -147,9 +193,11 @@ export async function retrieveProjectChunks(
   });
 
   if (redis) {
-    // Cache write is best-effort; don't fail the request if Redis is unavailable.
-    await redis.setex(key, budgets.toolCacheTtlSeconds, hits).catch(() => {
-      // Silently ignore cache write failures.
+    await writeProjectRetrievalCache({
+      key,
+      projectId: input.projectId,
+      redis,
+      value: hits,
     });
   }
 
@@ -298,8 +346,11 @@ export async function retrieveProjectArtifacts(
     .slice(0, topK);
 
   if (redis) {
-    await redis.setex(key, budgets.toolCacheTtlSeconds, hits).catch(() => {
-      // Ignore cache write failures.
+    await writeProjectRetrievalCache({
+      key,
+      projectId: input.projectId,
+      redis,
+      value: hits,
     });
   }
 

--- a/src/lib/artifacts/index-artifact.server.test.ts
+++ b/src/lib/artifacts/index-artifact.server.test.ts
@@ -40,6 +40,13 @@ vi.mock("@/lib/upstash/vector.server", () => ({
     `project:${projectId}:artifacts`,
 }));
 
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: async (
+    _input: unknown,
+    work: () => Promise<unknown>,
+  ) => await work(),
+}));
+
 async function loadModule() {
   vi.resetModules();
   return import("@/lib/artifacts/index-artifact.server");

--- a/src/lib/artifacts/index-artifact.server.ts
+++ b/src/lib/artifacts/index-artifact.server.ts
@@ -6,6 +6,7 @@ import { budgets } from "@/lib/config/budgets.server";
 import { AppError } from "@/lib/core/errors";
 import { sha256Hex } from "@/lib/core/sha256";
 import { getArtifactById } from "@/lib/data/artifacts.server";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 import {
   getVectorIndex,
   projectArtifactsNamespace,
@@ -141,12 +142,12 @@ export async function indexArtifactVersion(
   const vector = getVectorIndex().namespace(namespace);
   const chunkIdPrefix = `${baseId}:`;
 
-  // Cleanup first so shrinking chunk sets never leave stale vectors behind.
-  await vector.delete({ prefix: chunkIdPrefix });
-
   const markdown = getMarkdownContent(artifact.content);
   if (!markdown) {
     // Only markdown artifacts are indexed for retrieval today.
+    await withActiveProjectLease({ projectId: artifact.projectId }, () =>
+      vector.delete({ prefix: chunkIdPrefix }),
+    );
     return;
   }
 
@@ -169,27 +170,32 @@ export async function indexArtifactVersion(
     );
   }
 
-  await vector.upsert(
-    chunks.map((c, idx) => {
-      const meta: VectorMetadata = {
-        artifactId: artifact.id,
-        artifactKey: artifact.logicalKey,
-        artifactKind: artifact.kind,
-        artifactVersion: artifact.version,
-        // Extra fields for UI/search convenience (allowed via VectorDict).
-        chunkIndex: c.chunkIndex,
-        projectId: artifact.projectId,
-        snippet: c.snippet,
-        title: markdown.title,
-        type: "artifact",
-      };
+  await withActiveProjectLease({ projectId: artifact.projectId }, async () => {
+    // Cleanup and replacement share one lifecycle lease, so deletion cannot
+    // interleave with a partially replaced namespace.
+    await vector.delete({ prefix: chunkIdPrefix });
+    await vector.upsert(
+      chunks.map((c, idx) => {
+        const meta: VectorMetadata = {
+          artifactId: artifact.id,
+          artifactKey: artifact.logicalKey,
+          artifactKind: artifact.kind,
+          artifactVersion: artifact.version,
+          // Extra fields for UI/search convenience (allowed via VectorDict).
+          chunkIndex: c.chunkIndex,
+          projectId: artifact.projectId,
+          snippet: c.snippet,
+          title: markdown.title,
+          type: "artifact",
+        };
 
-      return {
-        data: c.text,
-        id: c.id,
-        metadata: meta,
-        vector: embeddings[idx],
-      };
-    }),
-  );
+        return {
+          data: c.text,
+          id: c.id,
+          metadata: meta,
+          vector: embeddings[idx],
+        };
+      }),
+    );
+  });
 }

--- a/src/lib/cache/tags.ts
+++ b/src/lib/cache/tags.ts
@@ -111,6 +111,25 @@ export function tagInfraResourcesIndex(projectId: string): string {
 }
 
 /**
+ * Return every cache tag whose value can contain project-owned data.
+ *
+ * @param projectId - Project identifier.
+ * @returns All project-scoped cache tags.
+ */
+export function projectCacheTags(projectId: string): readonly string[] {
+  return [
+    tagProject(projectId),
+    tagArtifactsIndex(projectId),
+    tagUploadsIndex(projectId),
+    tagReposIndex(projectId),
+    tagProjectSkillsIndex(projectId),
+    tagApprovalsIndex(projectId),
+    tagDeploymentsIndex(projectId),
+    tagInfraResourcesIndex(projectId),
+  ];
+}
+
+/**
  * Cache tag for the local model catalog JSON.
  *
  * @returns Stable cache tag.

--- a/src/lib/data/chat-start.server.test.ts
+++ b/src/lib/data/chat-start.server.test.ts
@@ -14,6 +14,7 @@ const input = {
   projectId: "project_1",
   threadId: "00000000-0000-4000-8000-000000000001",
   title: "hello",
+  userId: "user_1",
 };
 
 function threadRow(
@@ -52,6 +53,7 @@ function createIntentDb(options?: {
   }));
   let insertCount = 0;
   const tx = {
+    execute: vi.fn().mockResolvedValue(undefined),
     insert: vi.fn(() => {
       insertCount += 1;
       return { values: insertCount === 1 ? threadValues : messageValues };
@@ -67,6 +69,9 @@ function createIntentDb(options?: {
       },
       chatThreadsTable: {
         findFirst: vi.fn().mockResolvedValue(row),
+      },
+      projectsTable: {
+        findFirst: vi.fn().mockResolvedValue({ status: "active" }),
       },
     },
   };

--- a/src/lib/data/chat-start.server.ts
+++ b/src/lib/data/chat-start.server.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
 import { isDeepStrictEqual } from "node:util";
-import { and, eq, isNull, notInArray } from "drizzle-orm";
+import { and, eq, isNull, notInArray, sql } from "drizzle-orm";
 
 import { getDb } from "@/db/client";
 import * as schema from "@/db/schema";
@@ -32,6 +32,7 @@ type ChatStartIntent = Readonly<{
   projectId: string;
   threadId: string;
   title: string;
+  userId: string;
 }>;
 
 function toStartState(
@@ -86,6 +87,26 @@ export async function ensureChatStartIntent(
 
   try {
     return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${input.projectId}, 0))`,
+      );
+      const project = await tx.query.projectsTable.findFirst({
+        columns: { status: true },
+        where: and(
+          eq(schema.projectsTable.id, input.projectId),
+          eq(schema.projectsTable.ownerUserId, input.userId),
+        ),
+      });
+      if (!project) {
+        throw new AppError("project_not_found", 404, "Project not found.");
+      }
+      if (project.status !== "active") {
+        throw new AppError(
+          "project_not_active",
+          409,
+          "Restore the project before starting new work.",
+        );
+      }
       const now = new Date();
       const [created] = await tx
         .insert(schema.chatThreadsTable)

--- a/src/lib/data/deployments.server.ts
+++ b/src/lib/data/deployments.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { and, desc, eq } from "drizzle-orm";
 import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 
-import { getDb } from "@/db/client";
+import { type DbClient, getDb } from "@/db/client";
 import * as schema from "@/db/schema";
 import { tagDeploymentsIndex } from "@/lib/cache/tags";
 import { AppError } from "@/lib/core/errors";
@@ -90,6 +90,7 @@ export async function listDeploymentsByProject(
  * Create a deployment record (non-secret metadata only).
  *
  * @param input - Deployment identity and status.
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns Created deployment DTO.
  */
 export async function createDeploymentRecord(
@@ -105,8 +106,8 @@ export async function createDeploymentRecord(
     startedAt?: Date | null;
     endedAt?: Date | null;
   }>,
+  db: DbClient = getDb(),
 ): Promise<DeploymentDto> {
-  const db = getDb();
   const now = new Date();
 
   try {

--- a/src/lib/data/files.server.ts
+++ b/src/lib/data/files.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { and, eq } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
-import { getDb } from "@/db/client";
+import { type DbClient, getDb } from "@/db/client";
 import * as schema from "@/db/schema";
 import { tagUploadsIndex } from "@/lib/cache/tags";
 import { AppError } from "@/lib/core/errors";
@@ -41,6 +41,7 @@ function toProjectFileDto(row: FileRow): ProjectFileDto {
  * Create (or upsert) a project file record idempotently by `(projectId, sha256)`.
  *
  * @param input - File metadata including projectId, name, mimeType, sha256 hash, size, and storage URL.
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns File DTO.
  * @throws AppError - With code "db_insert_failed" if the database operation fails.
  */
@@ -53,9 +54,8 @@ export async function upsertProjectFile(
     sizeBytes: number;
     storageKey: string;
   }>,
+  db: DbClient = getDb(),
 ): Promise<ProjectFileDto> {
-  const db = getDb();
-
   const [row] = await db
     .insert(schema.projectFilesTable)
     .values({

--- a/src/lib/data/project-skills.server.ts
+++ b/src/lib/data/project-skills.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { and, asc, eq, sql } from "drizzle-orm";
 import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 
-import { getDb } from "@/db/client";
+import { type DbClient, getDb } from "@/db/client";
 import * as schema from "@/db/schema";
 import { tagProjectSkillsIndex } from "@/lib/cache/tags";
 import { AppError } from "@/lib/core/errors";
@@ -127,6 +127,7 @@ export async function getProjectSkillByName(
  *
  * @param projectId - Project ID.
  * @param registryId - Canonical registry identifier (`owner/repo/skillId`).
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns Matching skill or null.
  * @throws AppError - With code `"bad_request"` when `registryId` is empty.
  * @throws AppError - With code `"db_not_migrated"` when the database schema is missing/out-of-date.
@@ -134,13 +135,13 @@ export async function getProjectSkillByName(
 export async function findProjectSkillByRegistryId(
   projectId: string,
   registryId: string,
+  db: DbClient = getDb(),
 ): Promise<ProjectSkillDto | null> {
   const registryIdTrimmed = registryId.trim();
   if (!registryIdTrimmed) {
     throw new AppError("bad_request", 400, "Invalid registry id.");
   }
 
-  const db = getDb();
   try {
     const row = await db.query.projectSkillsTable.findFirst({
       where: and(
@@ -162,6 +163,7 @@ export async function findProjectSkillByRegistryId(
  *
  * @param projectId - Project ID.
  * @param name - Skill name.
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns Matching skill or null.
  * @throws AppError - With code `"bad_request"` when `name` is empty or exceeds 128 characters.
  * @throws AppError - With code `"db_not_migrated"` when the database schema is missing/out-of-date.
@@ -169,8 +171,8 @@ export async function findProjectSkillByRegistryId(
 export async function findProjectSkillByNameUncached(
   projectId: string,
   name: string,
+  db: DbClient = getDb(),
 ): Promise<ProjectSkillDto | null> {
-  const db = getDb();
   try {
     const nameNorm = normalizeSkillName(name);
     const row = await db.query.projectSkillsTable.findFirst({
@@ -217,9 +219,36 @@ export async function getProjectSkillById(
 }
 
 /**
+ * Find a project skill by id without Cache Components.
+ *
+ * @param projectId - Project ID.
+ * @param skillId - Skill ID.
+ * @param db - Database client, including a lifecycle transaction when supplied.
+ * @returns Matching skill or null.
+ */
+export async function findProjectSkillByIdUncached(
+  projectId: string,
+  skillId: string,
+  db: DbClient = getDb(),
+): Promise<ProjectSkillDto | null> {
+  try {
+    const row = await db.query.projectSkillsTable.findFirst({
+      where: and(
+        eq(schema.projectSkillsTable.projectId, projectId),
+        eq(schema.projectSkillsTable.id, skillId),
+      ),
+    });
+    return row ? toProjectSkillDto(row) : null;
+  } catch (err) {
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
  * Create or update a project skill (idempotent per projectId+name).
  *
  * @param input - Skill metadata and content.
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns Upserted skill.
  * @throws AppError - With code `"bad_request"` when `input.name` is empty or exceeds 128 characters.
  * @throws AppError - With code `"db_update_failed"` when the update returned no row.
@@ -234,8 +263,8 @@ export async function upsertProjectSkill(
     content: string;
     metadata?: Record<string, unknown>;
   }>,
+  db: DbClient = getDb(),
 ): Promise<ProjectSkillDto> {
-  const db = getDb();
   const now = new Date();
   const nameTrimmed = sanitizeSkillName(input.name);
   const nameNorm = nameTrimmed.toLowerCase();
@@ -310,6 +339,7 @@ export async function upsertProjectSkill(
  * drive updates even if the skill name changes.
  *
  * @param input - Update payload.
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns Updated skill.
  * @throws AppError - With code `"bad_request"` when `input.name` is empty or exceeds 128 characters.
  * @throws AppError - With code `"not_found"` when the skill does not exist.
@@ -326,8 +356,8 @@ export async function updateProjectSkillById(
     content: string;
     metadata?: Record<string, unknown>;
   }>,
+  db: DbClient = getDb(),
 ): Promise<ProjectSkillDto> {
-  const db = getDb();
   const now = new Date();
   const nameTrimmed = sanitizeSkillName(input.name);
   const nameNorm = nameTrimmed.toLowerCase();
@@ -388,15 +418,15 @@ export async function updateProjectSkillById(
  * Delete a project skill by id.
  *
  * @param input - Delete input.
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns Ok result.
  * @throws AppError - With code `"not_found"` when the skill does not exist.
  * @throws AppError - With code `"db_not_migrated"` when the database schema is missing/out-of-date.
  */
 export async function deleteProjectSkill(
   input: Readonly<{ projectId: string; skillId: string }>,
+  db: DbClient = getDb(),
 ): Promise<Readonly<{ ok: true }>> {
-  const db = getDb();
-
   try {
     const row = await db.query.projectSkillsTable.findFirst({
       where: and(

--- a/src/lib/data/project-upload-grants.server.test.ts
+++ b/src/lib/data/project-upload-grants.server.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  deleteWhere: vi.fn(),
+  execute: vi.fn(),
+  getDb: vi.fn(),
+  grantFindFirst: vi.fn(),
+  insertReturning: vi.fn(),
+  insertValues: vi.fn(),
+  projectFindFirst: vi.fn(),
+  transaction: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
+  withActiveProjectLease: vi.fn(),
+}));
+
+vi.mock("@/db/client", () => ({
+  getDb: () => state.getDb(),
+}));
+
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: state.withActiveProjectLease,
+}));
+
+const projectId = "11111111-1111-4111-8111-111111111111";
+const grantId = "22222222-2222-4222-8222-222222222222";
+
+function createFakeDb() {
+  const tx = {
+    delete: vi.fn(() => ({ where: state.deleteWhere })),
+    execute: state.execute,
+    insert: vi.fn(() => ({ values: state.insertValues })),
+    query: {
+      projectsTable: { findFirst: state.projectFindFirst },
+      projectUploadGrantsTable: { findFirst: state.grantFindFirst },
+    },
+    update: vi.fn(() => ({ set: state.updateSet })),
+  };
+  state.insertValues.mockReturnValue({ returning: state.insertReturning });
+  state.updateSet.mockReturnValue({ where: state.updateWhere });
+  state.transaction.mockImplementation(
+    async (work: (client: typeof tx) => Promise<unknown>) => await work(tx),
+  );
+  return { ...tx, transaction: state.transaction };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const db = createFakeDb();
+  state.getDb.mockReturnValue(db);
+  state.withActiveProjectLease.mockImplementation(
+    async (_input: unknown, work: (client: typeof db) => Promise<unknown>) =>
+      await work(db),
+  );
+  state.execute.mockResolvedValue(undefined);
+  state.insertReturning.mockResolvedValue([{ id: grantId }]);
+  state.deleteWhere.mockResolvedValue(undefined);
+  state.updateWhere.mockResolvedValue(undefined);
+  state.projectFindFirst.mockResolvedValue({ status: "active" });
+  state.grantFindFirst.mockResolvedValue({ id: grantId });
+});
+
+describe("project upload grants", () => {
+  it("commits a durable grant under the exact-owner active-project lease", async () => {
+    const { issueProjectUploadGrant } = await import(
+      "@/lib/data/project-upload-grants.server"
+    );
+    const expiresAt = new Date("2026-07-16T16:00:00.000Z");
+
+    await expect(
+      issueProjectUploadGrant({
+        expiresAt,
+        pathname: `projects/${projectId}/uploads/report.pdf`,
+        projectId,
+        userId: "user_1",
+      }),
+    ).resolves.toEqual({ id: grantId });
+
+    expect(state.withActiveProjectLease).toHaveBeenCalledWith(
+      { projectId, userId: "user_1" },
+      expect.any(Function),
+    );
+    expect(state.insertValues).toHaveBeenCalledWith({
+      expiresAt,
+      pathname: `projects/${projectId}/uploads/report.pdf`,
+      projectId,
+    });
+  });
+
+  it("settles an active project's signed completion under the lifecycle lock", async () => {
+    const { resolveProjectUploadCompletion } = await import(
+      "@/lib/data/project-upload-grants.server"
+    );
+
+    await expect(
+      resolveProjectUploadCompletion({
+        grantId,
+        projectId,
+      }),
+    ).resolves.toBe("keep");
+
+    expect(state.execute).toHaveBeenCalledOnce();
+    expect(state.updateSet).toHaveBeenCalledWith({
+      completedAt: expect.any(Date),
+    });
+  });
+
+  it("requires provider deletion when the project is no longer active", async () => {
+    state.projectFindFirst.mockResolvedValueOnce({ status: "deleting" });
+    const { resolveProjectUploadCompletion } = await import(
+      "@/lib/data/project-upload-grants.server"
+    );
+
+    await expect(
+      resolveProjectUploadCompletion({
+        grantId,
+        projectId,
+      }),
+    ).resolves.toBe("delete");
+    expect(state.updateSet).not.toHaveBeenCalled();
+  });
+
+  it("keeps deletion pending while an unexpired upload grant exists", async () => {
+    state.grantFindFirst.mockResolvedValueOnce({
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    const { assertProjectUploadGrantsSettled } = await import(
+      "@/lib/data/project-upload-grants.server"
+    );
+
+    await expect(
+      assertProjectUploadGrantsSettled(projectId),
+    ).rejects.toMatchObject({ code: "project_uploads_pending", status: 409 });
+    expect(state.deleteWhere).toHaveBeenCalledOnce();
+  });
+
+  it("allows the final prefix sweep after completed and expired grants are pruned", async () => {
+    state.grantFindFirst.mockResolvedValueOnce(undefined);
+    const { assertProjectUploadGrantsSettled } = await import(
+      "@/lib/data/project-upload-grants.server"
+    );
+
+    await expect(
+      assertProjectUploadGrantsSettled(projectId),
+    ).resolves.toBeUndefined();
+    expect(state.execute).toHaveBeenCalledOnce();
+    expect(state.deleteWhere).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/data/project-upload-grants.server.ts
+++ b/src/lib/data/project-upload-grants.server.ts
@@ -1,0 +1,179 @@
+import "server-only";
+
+import { and, eq, isNotNull, lte, or, sql } from "drizzle-orm";
+
+import { getDb } from "@/db/client";
+import * as schema from "@/db/schema";
+import { AppError } from "@/lib/core/errors";
+import { maybeWrapDbNotMigrated } from "@/lib/db/postgres-errors";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
+
+/** Five-minute capability window for direct-to-Blob client uploads. */
+export const PROJECT_UPLOAD_GRANT_TTL_MS = 5 * 60 * 1000;
+
+export type ProjectUploadCompletionDisposition = "delete" | "keep";
+
+/**
+ * Persist a client-upload capability while holding the project's active lease.
+ *
+ * The grant is committed before the bearer token is returned. A deletion claim
+ * therefore either precedes token issuance or observes the durable grant and
+ * keeps the project in its retryable `deleting` state until the token settles.
+ *
+ * @param input - Exact owner, project, pathname, and token expiry.
+ * @returns The durable grant identity embedded in the signed token payload.
+ */
+export async function issueProjectUploadGrant(
+  input: Readonly<{
+    expiresAt: Date;
+    pathname: string;
+    projectId: string;
+    userId: string;
+  }>,
+): Promise<Readonly<{ id: string }>> {
+  return await withActiveProjectLease(
+    { projectId: input.projectId, userId: input.userId },
+    async (db) => {
+      const [grant] = await db
+        .insert(schema.projectUploadGrantsTable)
+        .values({
+          expiresAt: input.expiresAt,
+          pathname: input.pathname,
+          projectId: input.projectId,
+        })
+        .returning({ id: schema.projectUploadGrantsTable.id });
+      if (!grant) {
+        throw new AppError(
+          "upload_grant_failed",
+          500,
+          "Failed to authorize the upload.",
+        );
+      }
+      return grant;
+    },
+  );
+}
+
+/**
+ * Resolve a signed upload-completion callback under the lifecycle lock.
+ *
+ * Active-project completions are marked settled and kept. Missing or inactive
+ * projects require provider cleanup; their grant remains pending until the
+ * caller confirms that Blob deletion succeeded.
+ *
+ * @param input - Signed grant and project identity.
+ * @returns Whether the uploaded Blob should be kept or deleted.
+ */
+export async function resolveProjectUploadCompletion(
+  input: Readonly<{ grantId: string; projectId: string }>,
+): Promise<ProjectUploadCompletionDisposition> {
+  const db = getDb();
+  try {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${input.projectId}, 0))`,
+      );
+      const project = await tx.query.projectsTable.findFirst({
+        columns: { status: true },
+        where: eq(schema.projectsTable.id, input.projectId),
+      });
+      if (!project || project.status !== "active") return "delete";
+
+      const grant = await tx.query.projectUploadGrantsTable.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(schema.projectUploadGrantsTable.id, input.grantId),
+          eq(schema.projectUploadGrantsTable.projectId, input.projectId),
+        ),
+      });
+      if (!grant) {
+        throw new AppError(
+          "upload_grant_not_found",
+          409,
+          "Upload authorization is no longer valid.",
+        );
+      }
+
+      await tx
+        .update(schema.projectUploadGrantsTable)
+        .set({ completedAt: new Date() })
+        .where(eq(schema.projectUploadGrantsTable.id, grant.id));
+      return "keep";
+    });
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
+ * Remove a rejected upload grant only after its Blob has been deleted.
+ *
+ * @param input - Signed grant and project identity.
+ */
+export async function removeRejectedProjectUploadGrant(
+  input: Readonly<{ grantId: string; projectId: string }>,
+): Promise<void> {
+  const db = getDb();
+  try {
+    await db
+      .delete(schema.projectUploadGrantsTable)
+      .where(
+        and(
+          eq(schema.projectUploadGrantsTable.id, input.grantId),
+          eq(schema.projectUploadGrantsTable.projectId, input.projectId),
+        ),
+      );
+  } catch (err) {
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
+ * Refuse final provider cleanup while any client-upload token can still write.
+ *
+ * Completed and expired grants are removed under the lifecycle lock. Once no
+ * live capability remains, deletion performs a fresh Blob prefix sweep before
+ * removing the project row.
+ *
+ * @param projectId - Deletion-pending project identity.
+ */
+export async function assertProjectUploadGrantsSettled(
+  projectId: string,
+): Promise<void> {
+  const db = getDb();
+  const now = new Date();
+  try {
+    await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${projectId}, 0))`,
+      );
+      await tx
+        .delete(schema.projectUploadGrantsTable)
+        .where(
+          and(
+            eq(schema.projectUploadGrantsTable.projectId, projectId),
+            or(
+              isNotNull(schema.projectUploadGrantsTable.completedAt),
+              lte(schema.projectUploadGrantsTable.expiresAt, now),
+            ),
+          ),
+        );
+      const pending = await tx.query.projectUploadGrantsTable.findFirst({
+        columns: { expiresAt: true },
+        orderBy: (grant, { asc }) => [asc(grant.expiresAt)],
+        where: eq(schema.projectUploadGrantsTable.projectId, projectId),
+      });
+      if (pending) {
+        throw new AppError(
+          "project_uploads_pending",
+          409,
+          `A client upload is still authorized. Retry deletion after ${pending.expiresAt.toISOString()}.`,
+        );
+      }
+    });
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw maybeWrapDbNotMigrated(err);
+  }
+}

--- a/src/lib/data/projects.server.test.ts
+++ b/src/lib/data/projects.server.test.ts
@@ -3,11 +3,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppError } from "@/lib/core/errors";
 
 const state = vi.hoisted(() => ({
+  artifactsFindMany: vi.fn(),
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
+  chatFindFirst: vi.fn(),
+  deleteReturning: vi.fn(),
+  deploymentFindFirst: vi.fn(),
+  execute: vi.fn(),
+  filesFindMany: vi.fn(),
   findFirst: vi.fn(),
   findMany: vi.fn(),
+  infraFindFirst: vi.fn(),
   insertReturning: vi.fn(),
+  projectSkillsFindMany: vi.fn(),
+  reposFindMany: vi.fn(),
+  runFindFirst: vi.fn(),
+  sandboxFindMany: vi.fn(),
+  updateReturning: vi.fn(),
 }));
 
 vi.mock("next/cache", () => ({
@@ -16,24 +28,61 @@ vi.mock("next/cache", () => ({
 }));
 
 vi.mock("@/db/client", () => ({
-  getDb: () => ({
-    insert: () => ({
-      values: () => ({
-        returning: state.insertReturning,
-      }),
-    }),
-    query: {
+  getDb: () => {
+    const query = {
+      artifactsTable: { findMany: state.artifactsFindMany },
+      chatThreadsTable: { findFirst: state.chatFindFirst },
+      deploymentsTable: { findFirst: state.deploymentFindFirst },
+      infraResourcesTable: { findFirst: state.infraFindFirst },
+      projectFilesTable: { findMany: state.filesFindMany },
+      projectSkillsTable: { findMany: state.projectSkillsFindMany },
       projectsTable: {
         findFirst: state.findFirst,
         findMany: state.findMany,
       },
-    },
-  }),
+      reposTable: { findMany: state.reposFindMany },
+      runsTable: { findFirst: state.runFindFirst },
+      sandboxJobsTable: { findMany: state.sandboxFindMany },
+    };
+    const db = {
+      delete: () => ({
+        where: () => ({ returning: state.deleteReturning }),
+      }),
+      insert: () => ({
+        values: () => ({
+          returning: state.insertReturning,
+        }),
+      }),
+      query,
+      update: () => ({
+        set: () => ({
+          where: () => ({ returning: state.updateReturning }),
+        }),
+      }),
+    };
+    return {
+      ...db,
+      transaction: async (callback: (tx: unknown) => Promise<unknown>) =>
+        await callback({ ...db, execute: state.execute }),
+    };
+  },
 }));
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.resetModules();
+  state.findFirst.mockResolvedValue(undefined);
+  state.updateReturning.mockResolvedValue([]);
+  state.artifactsFindMany.mockResolvedValue([]);
+  state.chatFindFirst.mockResolvedValue(undefined);
+  state.deploymentFindFirst.mockResolvedValue(undefined);
+  state.execute.mockResolvedValue(undefined);
+  state.filesFindMany.mockResolvedValue([]);
+  state.infraFindFirst.mockResolvedValue(undefined);
+  state.projectSkillsFindMany.mockResolvedValue([]);
+  state.reposFindMany.mockResolvedValue([]);
+  state.runFindFirst.mockResolvedValue(undefined);
+  state.sandboxFindMany.mockResolvedValue([]);
 });
 
 describe("projects DAL", () => {
@@ -264,5 +313,285 @@ describe("projects DAL", () => {
       code: "db_not_migrated",
       status: 500,
     } satisfies Partial<AppError>);
+  });
+
+  it("updates project metadata and lifecycle state for an exact owner", async () => {
+    const now = new Date(0);
+    state.findFirst.mockResolvedValue({
+      createdAt: now,
+      id: "proj_1",
+      name: "Renamed",
+      ownerUserId: "user_1",
+      slug: "renamed",
+      status: "active",
+      updatedAt: now,
+    });
+    state.updateReturning
+      .mockResolvedValueOnce([
+        {
+          createdAt: now,
+          id: "proj_1",
+          name: "Renamed",
+          ownerUserId: "user_1",
+          slug: "renamed",
+          status: "active",
+          updatedAt: now,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          createdAt: now,
+          id: "proj_1",
+          name: "Renamed",
+          ownerUserId: "user_1",
+          slug: "renamed",
+          status: "archived",
+          updatedAt: now,
+        },
+      ]);
+
+    const { setProjectStatusForUser, updateProjectForUser } = await import(
+      "@/lib/data/projects.server"
+    );
+    await expect(
+      updateProjectForUser({
+        name: " Renamed ",
+        projectId: "proj_1",
+        slug: "Renamed",
+        userId: "user_1",
+      }),
+    ).resolves.toMatchObject({ name: "Renamed", slug: "renamed" });
+    await expect(
+      setProjectStatusForUser({
+        projectId: "proj_1",
+        status: "archived",
+        userId: "user_1",
+      }),
+    ).resolves.toMatchObject({ status: "archived" });
+    expect(state.execute).toHaveBeenCalledTimes(2);
+  });
+
+  it("serializes archive with producers and blocks active work", async () => {
+    const now = new Date(0);
+    state.findFirst.mockResolvedValue({
+      createdAt: now,
+      id: "proj_1",
+      name: "Project",
+      ownerUserId: "user_1",
+      slug: "project",
+      status: "active",
+      updatedAt: now,
+    });
+    state.runFindFirst.mockResolvedValueOnce({ id: "run_1" });
+
+    const { setProjectStatusForUser } = await import(
+      "@/lib/data/projects.server"
+    );
+    await expect(
+      setProjectStatusForUser({
+        projectId: "proj_1",
+        status: "archived",
+        userId: "user_1",
+      }),
+    ).rejects.toMatchObject({ code: "project_has_active_work", status: 409 });
+    expect(state.execute).toHaveBeenCalledOnce();
+    expect(state.updateReturning).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate a missing or non-exactly-owned project", async () => {
+    state.updateReturning.mockResolvedValue([]);
+    const { setProjectStatusForUser, updateProjectForUser } = await import(
+      "@/lib/data/projects.server"
+    );
+
+    await expect(
+      updateProjectForUser({
+        name: "Project",
+        projectId: "proj_1",
+        slug: "project",
+        userId: "user_2",
+      }),
+    ).rejects.toMatchObject({ code: "project_not_found", status: 404 });
+    state.findFirst.mockResolvedValueOnce(undefined);
+    await expect(
+      setProjectStatusForUser({
+        projectId: "proj_1",
+        status: "archived",
+        userId: "user_2",
+      }),
+    ).rejects.toMatchObject({ code: "project_not_found", status: 404 });
+  });
+
+  it("atomically claims an archived idle project for deletion", async () => {
+    const now = new Date(0);
+    const archived = {
+      createdAt: now,
+      id: "proj_1",
+      name: "Project",
+      ownerUserId: "user_1",
+      slug: "project",
+      status: "archived",
+      updatedAt: now,
+    };
+    state.findFirst.mockResolvedValue(archived);
+    state.updateReturning.mockResolvedValueOnce([
+      { ...archived, status: "deleting" },
+    ]);
+
+    const { claimProjectDeletionForUser } = await import(
+      "@/lib/data/projects.server"
+    );
+    await expect(
+      claimProjectDeletionForUser({
+        confirmation: "project",
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).resolves.toMatchObject({ status: "deleting" });
+    expect(state.execute).toHaveBeenCalledOnce();
+  });
+
+  it("blocks a deletion claim while active work remains", async () => {
+    const now = new Date(0);
+    state.findFirst.mockResolvedValue({
+      createdAt: now,
+      id: "proj_1",
+      name: "Project",
+      ownerUserId: "user_1",
+      slug: "project",
+      status: "archived",
+      updatedAt: now,
+    });
+    const { claimProjectDeletionForUser } = await import(
+      "@/lib/data/projects.server"
+    );
+    const input = {
+      confirmation: "project",
+      projectId: "proj_1",
+      userId: "user_1",
+    } as const;
+
+    state.runFindFirst.mockResolvedValueOnce({ id: "run_1" });
+    await expect(claimProjectDeletionForUser(input)).rejects.toMatchObject({
+      code: "project_has_active_work",
+      status: 409,
+    });
+
+    expect(state.updateReturning).not.toHaveBeenCalled();
+  });
+
+  it("builds a deduplicated deletion plan for a claimed project", async () => {
+    const now = new Date(0);
+    state.findFirst.mockResolvedValue({
+      createdAt: now,
+      id: "proj_1",
+      name: "Project",
+      ownerUserId: "user_1",
+      slug: "project",
+      status: "deleting",
+      updatedAt: now,
+    });
+    state.filesFindMany.mockResolvedValue([
+      { storageKey: "blob/a" },
+      { storageKey: "blob/a" },
+      { storageKey: "blob/b" },
+    ]);
+    state.projectSkillsFindMany.mockResolvedValue([
+      {
+        metadata: {
+          bundle: {
+            blobPath: "blob/skill-bundle",
+            fileCount: 2,
+            format: "zip-v1",
+            sizeBytes: 128,
+          },
+        },
+      },
+    ]);
+    state.artifactsFindMany.mockResolvedValue([
+      { content: { blobPath: "blob/audit-bundle" } },
+      { content: { blobPath: 42 } },
+    ]);
+    state.sandboxFindMany.mockResolvedValue([
+      {
+        sandboxId: "sandbox_1",
+        sandboxStoppedAt: now,
+        status: "succeeded",
+        transcriptBlobRef: "blob/transcript",
+      },
+    ]);
+
+    const { prepareProjectDeletionForUser } = await import(
+      "@/lib/data/projects.server"
+    );
+    await expect(
+      prepareProjectDeletionForUser({
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).resolves.toEqual({
+      blobRefs: [
+        "blob/a",
+        "blob/b",
+        "blob/transcript",
+        "blob/skill-bundle",
+        "blob/audit-bundle",
+      ],
+      project: {
+        createdAt: now.toISOString(),
+        id: "proj_1",
+        name: "Project",
+        slug: "project",
+        status: "deleting",
+        updatedAt: now.toISOString(),
+      },
+    });
+  });
+
+  it("refuses cleanup until deletion has been claimed", async () => {
+    const now = new Date(0);
+    state.findFirst.mockResolvedValueOnce({
+      createdAt: now,
+      id: "proj_1",
+      name: "Project",
+      ownerUserId: "user_1",
+      slug: "project",
+      status: "active",
+      updatedAt: now,
+    });
+
+    const { prepareProjectDeletionForUser } = await import(
+      "@/lib/data/projects.server"
+    );
+    await expect(
+      prepareProjectDeletionForUser({
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).rejects.toMatchObject({ code: "project_not_claimed", status: 409 });
+  });
+
+  it("hard-deletes the archived row and reports concurrent changes", async () => {
+    state.deleteReturning.mockResolvedValueOnce([{ id: "proj_1" }]);
+    const { hardDeleteProjectForUser } = await import(
+      "@/lib/data/projects.server"
+    );
+    await expect(
+      hardDeleteProjectForUser({
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).resolves.toBeUndefined();
+
+    state.deleteReturning.mockResolvedValueOnce([]);
+    await expect(
+      hardDeleteProjectForUser({
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).rejects.toMatchObject({
+      code: "project_delete_conflict",
+      status: 409,
+    });
   });
 });

--- a/src/lib/data/projects.server.ts
+++ b/src/lib/data/projects.server.ts
@@ -1,10 +1,11 @@
 import "server-only";
 
-import { and, eq, or } from "drizzle-orm";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 
 import { getDb } from "@/db/client";
 import * as schema from "@/db/schema";
+import { getProjectSkillBundleRef } from "@/lib/ai/skills/project-skill-metadata.server";
 import { tagProject, tagProjectsIndex } from "@/lib/cache/tags";
 import { AppError } from "@/lib/core/errors";
 import { LEGACY_UNOWNED_PROJECT_OWNER_ID } from "@/lib/data/project-ownership";
@@ -20,10 +21,42 @@ export type ProjectDto = Readonly<{
   id: string;
   name: string;
   slug: string;
-  status: string;
+  status: ProjectStatus;
   createdAt: string;
   updatedAt: string;
 }>;
+
+/** Canonical project lifecycle states. */
+export type ProjectStatus = "active" | "archived" | "deleting";
+
+/** External resources that must be removed before the project row. */
+export type ProjectDeletionPlan = Readonly<{
+  blobRefs: readonly string[];
+  project: ProjectDto;
+}>;
+
+const ACTIVE_WORK_STATUSES = [
+  "pending",
+  "running",
+  "waiting",
+  "blocked",
+] as const;
+const ACTIVE_SANDBOX_JOB_STATUSES = new Set([
+  "pending",
+  "running",
+  "canceling",
+]);
+
+function parseProjectStatus(status: string): ProjectStatus {
+  if (status === "active" || status === "archived" || status === "deleting") {
+    return status;
+  }
+  throw new AppError(
+    "invalid_project_status",
+    500,
+    "Project has an unsupported lifecycle state.",
+  );
+}
 
 function toProjectDto(row: schema.Project): ProjectDto {
   return {
@@ -31,7 +64,7 @@ function toProjectDto(row: schema.Project): ProjectDto {
     id: row.id,
     name: row.name,
     slug: row.slug,
-    status: row.status,
+    status: parseProjectStatus(row.status),
     updatedAt: row.updatedAt.toISOString(),
   };
 }
@@ -44,17 +77,15 @@ function projectOwnerAccessFilter(userId: string) {
   return filter;
 }
 
-/**
- * Create a new project.
- *
- * @param input - Project creation inputs.
- * @returns Created project DTO.
- * @throws AppError - When inputs are invalid or project creation fails.
- */
-export async function createProject(
-  input: Readonly<{ name: string; slug: string; ownerUserId: string }>,
-): Promise<ProjectDto> {
-  const name = input.name.trim();
+function exactProjectOwnerFilter(projectId: string, userId: string) {
+  return and(
+    eq(schema.projectsTable.id, projectId),
+    eq(schema.projectsTable.ownerUserId, userId),
+  );
+}
+
+function normalizeProjectName(value: string): string {
+  const name = value.trim();
   if (name.length === 0 || name.length > 256) {
     throw new AppError(
       "invalid_input",
@@ -62,13 +93,11 @@ export async function createProject(
       "Project name must be between 1 and 256 characters.",
     );
   }
+  return name;
+}
 
-  const ownerUserId = input.ownerUserId.trim();
-  if (ownerUserId.length === 0) {
-    throw new AppError("invalid_input", 400, "Project owner is required.");
-  }
-
-  const slug = input.slug.trim().toLowerCase();
+function normalizeProjectSlug(value: string): string {
+  const slug = value.trim().toLowerCase();
   if (
     slug.length === 0 ||
     slug.length > 128 ||
@@ -80,6 +109,34 @@ export async function createProject(
       "Project slug must be lowercase alphanumeric with optional dashes.",
     );
   }
+  return slug;
+}
+
+function getAuditBundleBlobRef(
+  content: Record<string, unknown>,
+): string | null {
+  const blobPath = content.blobPath;
+  return typeof blobPath === "string" && blobPath.length > 0 ? blobPath : null;
+}
+
+/**
+ * Create a new project.
+ *
+ * @param input - Project creation inputs.
+ * @returns Created project DTO.
+ * @throws AppError - When inputs are invalid or project creation fails.
+ */
+export async function createProject(
+  input: Readonly<{ name: string; slug: string; ownerUserId: string }>,
+): Promise<ProjectDto> {
+  const name = normalizeProjectName(input.name);
+
+  const ownerUserId = input.ownerUserId.trim();
+  if (ownerUserId.length === 0) {
+    throw new AppError("invalid_input", 400, "Project owner is required.");
+  }
+
+  const slug = normalizeProjectSlug(input.slug);
 
   const db = getDb();
   let row: schema.Project | undefined;
@@ -97,6 +154,451 @@ export async function createProject(
   }
 
   return toProjectDto(row);
+}
+
+/**
+ * Update the display name and slug of a project owned by the authenticated user.
+ *
+ * Legacy sentinel-owned projects are intentionally read-only until their owner
+ * is backfilled; lifecycle mutations always require exact ownership.
+ *
+ * @param input - Project identity, exact owner, and new metadata.
+ * @returns Updated project DTO.
+ */
+export async function updateProjectForUser(
+  input: Readonly<{
+    projectId: string;
+    userId: string;
+    name: string;
+    slug: string;
+  }>,
+): Promise<ProjectDto> {
+  const name = normalizeProjectName(input.name);
+  const slug = normalizeProjectSlug(input.slug);
+  const db = getDb();
+  try {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${input.projectId}, 0))`,
+      );
+      const project = await tx.query.projectsTable.findFirst({
+        where: exactProjectOwnerFilter(input.projectId, input.userId),
+      });
+      if (!project) {
+        throw new AppError("project_not_found", 404, "Project not found.");
+      }
+      const status = parseProjectStatus(project.status);
+      if (status === "deleting") {
+        throw new AppError(
+          "project_deletion_pending",
+          409,
+          "Project deletion is pending and cannot be changed.",
+        );
+      }
+
+      const [row] = await tx
+        .update(schema.projectsTable)
+        .set({ name, slug, updatedAt: new Date() })
+        .where(
+          and(
+            exactProjectOwnerFilter(input.projectId, input.userId),
+            eq(schema.projectsTable.status, status),
+          ),
+        )
+        .returning();
+      if (!row) {
+        throw new AppError(
+          "project_status_conflict",
+          409,
+          "Project status changed. Refresh and try again.",
+        );
+      }
+      return toProjectDto(row);
+    });
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
+ * Archive or restore a project owned by the authenticated user.
+ *
+ * @param input - Project identity, exact owner, and target state.
+ * @returns Updated project DTO.
+ */
+export async function setProjectStatusForUser(
+  input: Readonly<{
+    projectId: string;
+    userId: string;
+    status: "active" | "archived";
+  }>,
+): Promise<ProjectDto> {
+  const db = getDb();
+  try {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${input.projectId}, 0))`,
+      );
+      const project = await tx.query.projectsTable.findFirst({
+        where: exactProjectOwnerFilter(input.projectId, input.userId),
+      });
+      if (!project) {
+        throw new AppError("project_not_found", 404, "Project not found.");
+      }
+
+      const status = parseProjectStatus(project.status);
+      if (status === "deleting") {
+        throw new AppError(
+          "project_deletion_pending",
+          409,
+          "Project deletion is pending and cannot be reversed.",
+        );
+      }
+      if (status === input.status) return toProjectDto(project);
+
+      if (input.status === "archived") {
+        const activeRun = await tx.query.runsTable.findFirst({
+          columns: { id: true },
+          where: and(
+            eq(schema.runsTable.projectId, input.projectId),
+            inArray(schema.runsTable.status, ACTIVE_WORK_STATUSES),
+          ),
+        });
+        const activeChat = await tx.query.chatThreadsTable.findFirst({
+          columns: { id: true },
+          where: and(
+            eq(schema.chatThreadsTable.projectId, input.projectId),
+            inArray(schema.chatThreadsTable.status, ACTIVE_WORK_STATUSES),
+          ),
+        });
+        const sandboxJobs = await tx.query.sandboxJobsTable.findMany({
+          columns: { sandboxId: true, sandboxStoppedAt: true, status: true },
+          where: eq(schema.sandboxJobsTable.projectId, input.projectId),
+        });
+        const activeSandbox = sandboxJobs.some(
+          (job) =>
+            ACTIVE_SANDBOX_JOB_STATUSES.has(job.status) ||
+            (job.sandboxId !== null && job.sandboxStoppedAt === null),
+        );
+        if (activeRun || activeChat || activeSandbox) {
+          throw new AppError(
+            "project_has_active_work",
+            409,
+            "Finish or cancel active runs, chats, and sandboxes before archiving this project.",
+          );
+        }
+      }
+
+      const [row] = await tx
+        .update(schema.projectsTable)
+        .set({ status: input.status, updatedAt: new Date() })
+        .where(
+          and(
+            exactProjectOwnerFilter(input.projectId, input.userId),
+            eq(schema.projectsTable.status, status),
+          ),
+        )
+        .returning();
+      if (!row) {
+        throw new AppError(
+          "project_status_conflict",
+          409,
+          "Project status changed. Refresh and try again.",
+        );
+      }
+      return toProjectDto(row);
+    });
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
+ * Atomically claim an archived project for irreversible deletion.
+ *
+ * The project-scoped advisory lock coordinates this state transition with all
+ * resource-producing leases. Once claimed, metadata changes and restoration
+ * are fenced while provider cleanup remains retryable.
+ *
+ * @param input - Project identity, exact owner, and typed slug confirmation.
+ * @returns The claimed project in `deleting` state.
+ */
+export async function claimProjectDeletionForUser(
+  input: Readonly<{
+    confirmation: string;
+    projectId: string;
+    userId: string;
+  }>,
+): Promise<ProjectDto> {
+  const db = getDb();
+  try {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${input.projectId}, 0))`,
+      );
+      const project = await tx.query.projectsTable.findFirst({
+        where: exactProjectOwnerFilter(input.projectId, input.userId),
+      });
+      if (!project) {
+        throw new AppError("project_not_found", 404, "Project not found.");
+      }
+      if (input.confirmation.trim() !== project.slug) {
+        throw new AppError(
+          "project_confirmation_mismatch",
+          400,
+          "Type the project slug exactly to confirm deletion.",
+        );
+      }
+      const status = parseProjectStatus(project.status);
+      if (status === "deleting") return toProjectDto(project);
+      if (status !== "archived") {
+        throw new AppError(
+          "project_not_archived",
+          409,
+          "Archive the project before deleting it.",
+        );
+      }
+
+      const activeRun = await tx.query.runsTable.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(schema.runsTable.projectId, input.projectId),
+          inArray(schema.runsTable.status, ACTIVE_WORK_STATUSES),
+        ),
+      });
+      const activeChat = await tx.query.chatThreadsTable.findFirst({
+        columns: { id: true },
+        where: and(
+          eq(schema.chatThreadsTable.projectId, input.projectId),
+          inArray(schema.chatThreadsTable.status, ACTIVE_WORK_STATUSES),
+        ),
+      });
+      const sandboxJobs = await tx.query.sandboxJobsTable.findMany({
+        columns: { sandboxId: true, sandboxStoppedAt: true, status: true },
+        where: eq(schema.sandboxJobsTable.projectId, input.projectId),
+      });
+      const activeSandbox = sandboxJobs.some(
+        (job) =>
+          ACTIVE_SANDBOX_JOB_STATUSES.has(job.status) ||
+          (job.sandboxId !== null && job.sandboxStoppedAt === null),
+      );
+      if (activeRun || activeChat || activeSandbox) {
+        throw new AppError(
+          "project_has_active_work",
+          409,
+          "Finish or cancel active runs, chats, and sandboxes before deleting this project.",
+        );
+      }
+
+      const [claimed] = await tx
+        .update(schema.projectsTable)
+        .set({ status: "deleting", updatedAt: new Date() })
+        .where(
+          and(
+            exactProjectOwnerFilter(input.projectId, input.userId),
+            eq(schema.projectsTable.status, "archived"),
+          ),
+        )
+        .returning();
+      if (!claimed) {
+        throw new AppError(
+          "project_status_conflict",
+          409,
+          "Project status changed. Refresh and try again.",
+        );
+      }
+      return toProjectDto(claimed);
+    });
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
+ * Build a retry-safe project deletion plan after enforcing lifecycle guards.
+ *
+ * @param input - Project identity and exact owner.
+ * @returns External resources and project metadata needed for deletion.
+ */
+export async function prepareProjectDeletionForUser(
+  input: Readonly<{ projectId: string; userId: string }>,
+): Promise<ProjectDeletionPlan> {
+  const db = getDb();
+  try {
+    const project = await db.query.projectsTable.findFirst({
+      where: exactProjectOwnerFilter(input.projectId, input.userId),
+    });
+    if (!project) {
+      throw new AppError("project_not_found", 404, "Project not found.");
+    }
+    if (parseProjectStatus(project.status) !== "deleting") {
+      throw new AppError(
+        "project_not_claimed",
+        409,
+        "Claim the project for deletion before cleanup.",
+      );
+    }
+
+    const [files, sandboxJobs, projectSkills, auditBundles] = await Promise.all(
+      [
+        db.query.projectFilesTable.findMany({
+          columns: { storageKey: true },
+          where: eq(schema.projectFilesTable.projectId, input.projectId),
+        }),
+        db.query.sandboxJobsTable.findMany({
+          columns: {
+            sandboxId: true,
+            sandboxStoppedAt: true,
+            status: true,
+            transcriptBlobRef: true,
+          },
+          where: eq(schema.sandboxJobsTable.projectId, input.projectId),
+        }),
+        db.query.projectSkillsTable.findMany({
+          columns: { metadata: true },
+          where: eq(schema.projectSkillsTable.projectId, input.projectId),
+        }),
+        db.query.artifactsTable.findMany({
+          columns: { content: true },
+          where: and(
+            eq(schema.artifactsTable.projectId, input.projectId),
+            eq(schema.artifactsTable.kind, "IMPLEMENTATION_AUDIT_BUNDLE"),
+          ),
+        }),
+      ],
+    );
+
+    const blobRefs = new Set(files.map((file) => file.storageKey));
+    for (const job of sandboxJobs) {
+      if (job.transcriptBlobRef) blobRefs.add(job.transcriptBlobRef);
+    }
+    for (const skill of projectSkills) {
+      const bundle = getProjectSkillBundleRef(skill.metadata);
+      if (bundle) blobRefs.add(bundle.blobPath);
+    }
+    for (const artifact of auditBundles) {
+      const blobRef = getAuditBundleBlobRef(artifact.content);
+      if (blobRef) blobRefs.add(blobRef);
+    }
+
+    return {
+      blobRefs: [...blobRefs],
+      project: toProjectDto(project),
+    };
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
+ * Delete the archived project row after its external resources are removed.
+ *
+ * @param input - Project identity and exact owner.
+ */
+export async function hardDeleteProjectForUser(
+  input: Readonly<{ projectId: string; userId: string }>,
+): Promise<void> {
+  const db = getDb();
+  let row: Readonly<{ id: string }> | undefined;
+  try {
+    [row] = await db
+      .delete(schema.projectsTable)
+      .where(
+        and(
+          exactProjectOwnerFilter(input.projectId, input.userId),
+          eq(schema.projectsTable.status, "deleting"),
+        ),
+      )
+      .returning({ id: schema.projectsTable.id });
+  } catch (err) {
+    throw maybeWrapDbNotMigrated(err);
+  }
+
+  if (!row) {
+    throw new AppError(
+      "project_delete_conflict",
+      409,
+      "Project changed before deletion. Refresh and try again.",
+    );
+  }
+}
+
+/**
+ * Read an exactly owned project without request caching.
+ *
+ * Use this at authenticated mutation boundaries. Legacy sentinel-owned
+ * projects remain readable through the cached compatibility queries but are
+ * never mutation authorities.
+ *
+ * @param id - Project identifier.
+ * @param userId - Exact authenticated owner identifier.
+ * @returns Exactly owned project, or `null`.
+ */
+export async function getOwnedProjectByIdForUser(
+  id: string,
+  userId: string,
+): Promise<ProjectDto | null> {
+  const db = getDb();
+  try {
+    const row = await db.query.projectsTable.findFirst({
+      where: exactProjectOwnerFilter(id, userId),
+    });
+    return row ? toProjectDto(row) : null;
+  } catch (err) {
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
+ * Read an exactly owned active project without request caching.
+ *
+ * @param id - Project identifier.
+ * @param userId - Exact authenticated owner identifier.
+ * @returns The active project, or `null` for missing, legacy-owned, archived,
+ * or deletion-pending projects.
+ */
+export async function getActiveProjectByIdForUser(
+  id: string,
+  userId: string,
+): Promise<ProjectDto | null> {
+  const db = getDb();
+  try {
+    const row = await db.query.projectsTable.findFirst({
+      where: and(
+        exactProjectOwnerFilter(id, userId),
+        eq(schema.projectsTable.status, "active"),
+      ),
+    });
+    return row ? toProjectDto(row) : null;
+  } catch (err) {
+    throw maybeWrapDbNotMigrated(err);
+  }
+}
+
+/**
+ * Check whether a project is currently active without request caching.
+ *
+ * @param projectId - Project identifier.
+ * @returns Whether the project exists in the active state.
+ */
+export async function isProjectActive(projectId: string): Promise<boolean> {
+  const db = getDb();
+  try {
+    const row = await db.query.projectsTable.findFirst({
+      columns: { id: true },
+      where: and(
+        eq(schema.projectsTable.id, projectId),
+        eq(schema.projectsTable.status, "active"),
+      ),
+    });
+    return Boolean(row);
+  } catch (err) {
+    throw maybeWrapDbNotMigrated(err);
+  }
 }
 
 /**

--- a/src/lib/data/repos.server.ts
+++ b/src/lib/data/repos.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { and, asc, eq } from "drizzle-orm";
 import { cacheLife, cacheTag, revalidateTag } from "next/cache";
 
-import { getDb } from "@/db/client";
+import { type DbClient, getDb } from "@/db/client";
 import * as schema from "@/db/schema";
 import { tagReposIndex } from "@/lib/cache/tags";
 import { AppError } from "@/lib/core/errors";
@@ -75,6 +75,7 @@ export async function listReposByProject(
  * This is idempotent per `(projectId, provider, owner, name)`.
  *
  * @param input - Repo connection metadata.
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns Upserted repo DTO.
  */
 export async function upsertRepoConnection(
@@ -87,8 +88,8 @@ export async function upsertRepoConnection(
     htmlUrl: string;
     defaultBranch: string;
   }>,
+  db: DbClient = getDb(),
 ): Promise<RepoDto> {
-  const db = getDb();
   const now = new Date();
 
   try {

--- a/src/lib/data/runs.server.ts
+++ b/src/lib/data/runs.server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { and, eq, isNull, notInArray } from "drizzle-orm";
 import { cache } from "react";
-import { getDb } from "@/db/client";
+import { type DbClient, getDb } from "@/db/client";
 import * as schema from "@/db/schema";
 import { AppError } from "@/lib/core/errors";
 import { cancelRunAndStepsTx } from "@/lib/data/run-cancel-tx";
@@ -95,6 +95,7 @@ function toRunStepDto(row: RunStepRow): RunStepDto {
  * Create a new run for a project.
  *
  * @param input - Run creation inputs.
+ * @param db - Database client, including a lifecycle transaction when supplied.
  * @returns Created run DTO.
  * @throws AppError - With code "db_insert_failed" (500) when run creation fails.
  */
@@ -104,8 +105,8 @@ export async function createRun(
     kind: RunDto["kind"];
     metadata?: Record<string, unknown>;
   }>,
+  db: DbClient = getDb(),
 ): Promise<RunDto> {
-  const db = getDb();
   const [row] = await db
     .insert(schema.runsTable)
     .values({

--- a/src/lib/ingest/ingest-file.server.test.ts
+++ b/src/lib/ingest/ingest-file.server.test.ts
@@ -46,28 +46,29 @@ vi.mock("@/lib/upstash/vector.server", () => ({
   projectChunksNamespace: (projectId: string) => `project:${projectId}:chunks`,
 }));
 
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: async (
+    _input: unknown,
+    work: (db: DbClient) => Promise<unknown>,
+  ) => await work(state.getDb()),
+}));
+
 function createFakeDb() {
-  const tx = {
+  const db = {
     delete: vi
       .fn()
       .mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
     insert: vi
       .fn()
       .mockReturnValue({ values: vi.fn().mockResolvedValue(undefined) }),
-  } as unknown as DbClient;
-
-  const db = {
-    delete: vi
-      .fn()
-      .mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
     transaction: vi
       .fn()
       .mockImplementation(async (cb: (tx: DbClient) => Promise<unknown>) => {
-        await cb(tx);
+        await cb(db as unknown as DbClient);
       }),
   };
 
-  return { db, tx };
+  return db as unknown as DbClient;
 }
 
 beforeEach(() => {
@@ -81,7 +82,7 @@ beforeEach(() => {
     upsert: state.vectorUpsert,
   });
 
-  const { db } = createFakeDb();
+  const db = createFakeDb();
   state.getDb.mockReturnValue(db);
 
   state.extractDocument.mockResolvedValue({
@@ -192,7 +193,7 @@ describe("ingestFile", () => {
   });
 
   it("cleans up vectors and DB rows when vector upsert fails", async () => {
-    const { db } = createFakeDb();
+    const db = createFakeDb();
     state.getDb.mockReturnValue(db);
 
     const chunks: readonly FakeChunk[] = [

--- a/src/lib/ingest/ingest-file.server.ts
+++ b/src/lib/ingest/ingest-file.server.ts
@@ -2,13 +2,13 @@ import "server-only";
 
 import { eq } from "drizzle-orm";
 
-import { getDb } from "@/db/client";
 import * as schema from "@/db/schema";
 import { embedTexts } from "@/lib/ai/embeddings.server";
 import { budgets } from "@/lib/config/budgets.server";
 import { AppError } from "@/lib/core/errors";
 import { chunkDocument } from "@/lib/ingest/chunk/chunk-document.server";
 import { extractDocument } from "@/lib/ingest/extract/extract-document.server";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 import {
   getVectorIndex,
   projectChunksNamespace,
@@ -71,17 +71,16 @@ export async function ingestFile(
     throw new AppError("embed_failed", 500, "Embedding batch size mismatch.");
   }
 
-  const db = getDb();
   const vector = getVectorIndex().namespace(
     projectChunksNamespace(input.projectId),
   );
 
-  await db.transaction(async (tx) => {
-    await tx
+  await withActiveProjectLease({ projectId: input.projectId }, async (db) => {
+    await db
       .delete(schema.fileChunksTable)
       .where(eq(schema.fileChunksTable.fileId, input.fileId));
 
-    await tx.insert(schema.fileChunksTable).values(
+    await db.insert(schema.fileChunksTable).values(
       chunks.map((c) => ({
         chunkIndex: c.chunkIndex,
         content: c.content,
@@ -93,39 +92,36 @@ export async function ingestFile(
         tokenCount: c.tokenCount ?? null,
       })),
     );
-  });
 
-  // Ensure stale vectors are removed (e.g., extraction version changes).
-  try {
-    await vector.delete({ prefix: `${input.fileId}:` });
-
-    await vector.upsert(
-      chunks.map((c, idx) => ({
-        id: c.id,
-        metadata: {
-          chunkId: c.id,
-          chunkIndex: c.chunkIndex,
-          fileId: input.fileId,
-          projectId: input.projectId,
-          snippet: c.content.slice(0, 280),
-          type: "chunk",
-          ...(c.pageStart === undefined ? {} : { pageStart: c.pageStart }),
-          ...(c.pageEnd === undefined ? {} : { pageEnd: c.pageEnd }),
-        } satisfies VectorMetadata,
-        vector: embeddings[idx] as number[],
-      })),
-    );
-  } catch (error) {
+    // Ensure stale vectors are removed (e.g., extraction version changes).
     try {
       await vector.delete({ prefix: `${input.fileId}:` });
-    } catch {
-      // Best-effort cleanup; preserve original failure.
+
+      await vector.upsert(
+        chunks.map((c, idx) => ({
+          id: c.id,
+          metadata: {
+            chunkId: c.id,
+            chunkIndex: c.chunkIndex,
+            fileId: input.fileId,
+            projectId: input.projectId,
+            snippet: c.content.slice(0, 280),
+            type: "chunk",
+            ...(c.pageStart === undefined ? {} : { pageStart: c.pageStart }),
+            ...(c.pageEnd === undefined ? {} : { pageEnd: c.pageEnd }),
+          } satisfies VectorMetadata,
+          vector: embeddings[idx] as number[],
+        })),
+      );
+    } catch (error) {
+      try {
+        await vector.delete({ prefix: `${input.fileId}:` });
+      } catch {
+        // Best-effort cleanup; preserve original failure.
+      }
+      throw error;
     }
-    await db
-      .delete(schema.fileChunksTable)
-      .where(eq(schema.fileChunksTable.fileId, input.fileId));
-    throw error;
-  }
+  });
 
   return { chunksIndexed: chunks.length, fileId: input.fileId };
 }

--- a/src/lib/projects/delete-project.server.test.ts
+++ b/src/lib/projects/delete-project.server.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  assertProjectUploadGrantsSettled: vi.fn(),
+  claimProjectDeletionForUser: vi.fn(),
+  del: vi.fn(),
+  deleteNamespace: vi.fn(),
+  hardDeleteProjectForUser: vi.fn(),
+  list: vi.fn(),
+  listNamespaces: vi.fn(),
+  prepareProjectDeletionForUser: vi.fn(),
+  purgeProjectRetrievalCache: vi.fn(),
+}));
+
+vi.mock("@vercel/blob", () => ({ del: state.del, list: state.list }));
+
+vi.mock("@/lib/ai/tools/retrieval.server", () => ({
+  purgeProjectRetrievalCache: state.purgeProjectRetrievalCache,
+}));
+
+vi.mock("@/lib/data/project-upload-grants.server", () => ({
+  assertProjectUploadGrantsSettled: state.assertProjectUploadGrantsSettled,
+}));
+
+vi.mock("@/lib/data/projects.server", () => ({
+  claimProjectDeletionForUser: state.claimProjectDeletionForUser,
+  hardDeleteProjectForUser: state.hardDeleteProjectForUser,
+  prepareProjectDeletionForUser: state.prepareProjectDeletionForUser,
+}));
+
+vi.mock("@/lib/env", () => ({
+  env: { blob: { readWriteToken: "blob_token" } },
+}));
+
+vi.mock("@/lib/upstash/vector.server", () => ({
+  getVectorIndex: () => ({
+    deleteNamespace: state.deleteNamespace,
+    listNamespaces: state.listNamespaces,
+  }),
+  projectArtifactsNamespace: (projectId: string) =>
+    `project:${projectId}:artifacts`,
+  projectChunksNamespace: (projectId: string) => `project:${projectId}:chunks`,
+  projectRepoNamespace: (projectId: string, repoId: string) =>
+    `project:${projectId}:repo:${repoId}`,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.del.mockResolvedValue(undefined);
+  state.assertProjectUploadGrantsSettled.mockResolvedValue(undefined);
+  state.claimProjectDeletionForUser.mockResolvedValue({
+    slug: "project",
+    status: "deleting",
+  });
+  state.deleteNamespace.mockResolvedValue("ok");
+  state.hardDeleteProjectForUser.mockResolvedValue(undefined);
+  state.listNamespaces.mockResolvedValue([
+    "project:proj_1:chunks",
+    "project:proj_1:artifacts",
+    "project:proj_1:repo:repo_1",
+    "project:proj_1:future:orphan",
+    "project:another-project:chunks",
+  ]);
+  state.list.mockResolvedValue({ blobs: [], hasMore: false });
+  state.purgeProjectRetrievalCache.mockResolvedValue(undefined);
+  state.prepareProjectDeletionForUser.mockResolvedValue({
+    blobRefs: ["blob/a", "blob/b"],
+    project: { slug: "project" },
+  });
+});
+
+describe("deleteProjectForUser", () => {
+  it("requires the exact project slug before cleanup", async () => {
+    state.claimProjectDeletionForUser.mockRejectedValueOnce(
+      Object.assign(new Error("Type the project slug exactly."), {
+        code: "project_confirmation_mismatch",
+        status: 400,
+      }),
+    );
+    const { deleteProjectForUser } = await import(
+      "@/lib/projects/delete-project.server"
+    );
+    await expect(
+      deleteProjectForUser({
+        confirmation: "wrong",
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).rejects.toMatchObject({
+      code: "project_confirmation_mismatch",
+      status: 400,
+    });
+    expect(state.del).not.toHaveBeenCalled();
+    expect(state.deleteNamespace).not.toHaveBeenCalled();
+    expect(state.hardDeleteProjectForUser).not.toHaveBeenCalled();
+  });
+
+  it("deletes blobs and every vector namespace before the database row", async () => {
+    state.list
+      .mockResolvedValueOnce({
+        blobs: [{ url: "blob/prefix-only" }],
+        cursor: "next-page",
+        hasMore: true,
+      })
+      .mockResolvedValueOnce({
+        blobs: [{ url: "blob/second-page" }],
+        hasMore: false,
+      });
+    const { deleteProjectForUser } = await import(
+      "@/lib/projects/delete-project.server"
+    );
+    await deleteProjectForUser({
+      confirmation: "project",
+      projectId: "proj_1",
+      userId: "user_1",
+    });
+
+    expect(state.del).toHaveBeenCalledWith(
+      ["blob/a", "blob/b", "blob/prefix-only", "blob/second-page"],
+      {
+        token: "blob_token",
+      },
+    );
+    expect(
+      state.deleteNamespace.mock.calls.map(([namespace]) => namespace),
+    ).toEqual([
+      "project:proj_1:chunks",
+      "project:proj_1:artifacts",
+      "project:proj_1:repo:repo_1",
+      "project:proj_1:future:orphan",
+    ]);
+    expect(state.hardDeleteProjectForUser).toHaveBeenCalledWith({
+      confirmation: "project",
+      projectId: "proj_1",
+      userId: "user_1",
+    });
+    expect(state.purgeProjectRetrievalCache).toHaveBeenCalledWith("proj_1");
+  });
+
+  it("keeps the deletion tombstone until every issued upload token settles", async () => {
+    state.assertProjectUploadGrantsSettled.mockRejectedValueOnce(
+      Object.assign(new Error("Client upload still authorized."), {
+        code: "project_uploads_pending",
+        status: 409,
+      }),
+    );
+    const { deleteProjectForUser } = await import(
+      "@/lib/projects/delete-project.server"
+    );
+
+    await expect(
+      deleteProjectForUser({
+        confirmation: "project",
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).rejects.toMatchObject({ code: "project_uploads_pending", status: 409 });
+
+    expect(state.claimProjectDeletionForUser).toHaveBeenCalledOnce();
+    expect(state.prepareProjectDeletionForUser).not.toHaveBeenCalled();
+    expect(state.list).not.toHaveBeenCalled();
+    expect(state.hardDeleteProjectForUser).not.toHaveBeenCalled();
+  });
+
+  it("keeps the database row when external cleanup fails", async () => {
+    state.deleteNamespace.mockRejectedValueOnce(
+      new Error("vector unavailable"),
+    );
+    const { deleteProjectForUser } = await import(
+      "@/lib/projects/delete-project.server"
+    );
+    await expect(
+      deleteProjectForUser({
+        confirmation: "project",
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).rejects.toMatchObject({ code: "project_vector_cleanup_failed" });
+    expect(state.hardDeleteProjectForUser).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when Blob pagination omits its continuation cursor", async () => {
+    state.list.mockResolvedValueOnce({
+      blobs: [],
+      hasMore: true,
+    });
+    const { deleteProjectForUser } = await import(
+      "@/lib/projects/delete-project.server"
+    );
+    await expect(
+      deleteProjectForUser({
+        confirmation: "project",
+        projectId: "proj_1",
+        userId: "user_1",
+      }),
+    ).rejects.toMatchObject({ code: "project_blob_cleanup_failed" });
+    expect(state.hardDeleteProjectForUser).not.toHaveBeenCalled();
+  });
+
+  it("deletes an empty project without calling missing namespaces", async () => {
+    state.prepareProjectDeletionForUser.mockResolvedValueOnce({
+      blobRefs: [],
+      project: { slug: "project" },
+    });
+    state.listNamespaces.mockResolvedValueOnce([]);
+    const { deleteProjectForUser } = await import(
+      "@/lib/projects/delete-project.server"
+    );
+    await deleteProjectForUser({
+      confirmation: "project",
+      projectId: "proj_1",
+      userId: "user_1",
+    });
+
+    expect(state.del).not.toHaveBeenCalled();
+    expect(state.deleteNamespace).not.toHaveBeenCalled();
+    expect(state.hardDeleteProjectForUser).toHaveBeenCalledOnce();
+  });
+
+  it("deletes only namespaces that remain after a partial retry", async () => {
+    state.listNamespaces.mockResolvedValueOnce([
+      "project:proj_1:repo:repo_1",
+      "project:another-project:chunks",
+    ]);
+    const { deleteProjectForUser } = await import(
+      "@/lib/projects/delete-project.server"
+    );
+    await deleteProjectForUser({
+      confirmation: "project",
+      projectId: "proj_1",
+      userId: "user_1",
+    });
+
+    expect(state.deleteNamespace).toHaveBeenCalledOnce();
+    expect(state.deleteNamespace).toHaveBeenCalledWith(
+      "project:proj_1:repo:repo_1",
+    );
+    expect(state.hardDeleteProjectForUser).toHaveBeenCalledOnce();
+  });
+});

--- a/src/lib/projects/delete-project.server.ts
+++ b/src/lib/projects/delete-project.server.ts
@@ -1,0 +1,113 @@
+import "server-only";
+
+import { del, list } from "@vercel/blob";
+import { purgeProjectRetrievalCache } from "@/lib/ai/tools/retrieval.server";
+import { AppError } from "@/lib/core/errors";
+import { log } from "@/lib/core/log";
+import { assertProjectUploadGrantsSettled } from "@/lib/data/project-upload-grants.server";
+import {
+  claimProjectDeletionForUser,
+  hardDeleteProjectForUser,
+  prepareProjectDeletionForUser,
+} from "@/lib/data/projects.server";
+import { env } from "@/lib/env";
+import { getVectorIndex } from "@/lib/upstash/vector.server";
+
+/**
+ * Delete an archived project and every app-owned external resource it references.
+ *
+ * External cleanup happens before the cascading database delete. Vercel Blob
+ * deletion is idempotent, and Upstash namespaces are discovered before removal
+ * so missing namespaces are treated as already clean. A failed final database
+ * write can therefore be retried without orphaning external data.
+ *
+ * @param input - Project identity and exact authenticated owner.
+ */
+export async function deleteProjectForUser(
+  input: Readonly<{
+    confirmation: string;
+    projectId: string;
+    userId: string;
+  }>,
+): Promise<void> {
+  await claimProjectDeletionForUser(input);
+  // A token granted before the deletion claim is still a provider write
+  // capability. Keep the durable project tombstone until every grant has
+  // completed or expired, then make the Blob listing below the final sweep.
+  await assertProjectUploadGrantsSettled(input.projectId);
+  const plan = await prepareProjectDeletionForUser(input);
+
+  try {
+    const blobToken = env.blob.readWriteToken;
+    const refs = new Set(plan.blobRefs);
+    let cursor: string | undefined;
+    do {
+      const page = await list({
+        ...(cursor ? { cursor } : {}),
+        limit: 1000,
+        prefix: `projects/${input.projectId}/`,
+        token: blobToken,
+      });
+      for (const blob of page.blobs) refs.add(blob.url);
+      if (page.hasMore && !page.cursor) {
+        throw new Error("Blob listing did not return a pagination cursor.");
+      }
+      cursor = page.hasMore ? page.cursor : undefined;
+    } while (cursor);
+
+    const blobRefs = [...refs];
+    for (let index = 0; index < blobRefs.length; index += 100) {
+      await del(blobRefs.slice(index, index + 100), { token: blobToken });
+    }
+  } catch (err) {
+    log.error("project_blob_cleanup_failed", {
+      err,
+      projectId: input.projectId,
+    });
+    throw new AppError(
+      "project_blob_cleanup_failed",
+      502,
+      "Blob cleanup failed; project deletion remains pending. Retry deletion.",
+      err,
+    );
+  }
+
+  try {
+    const vectorIndex = getVectorIndex();
+    const namespacePrefix = `project:${input.projectId}:`;
+    const namespaces = (await vectorIndex.listNamespaces()).filter(
+      (namespace) => namespace.startsWith(namespacePrefix),
+    );
+    for (const namespace of namespaces) {
+      await vectorIndex.deleteNamespace(namespace);
+    }
+  } catch (err) {
+    log.error("project_vector_cleanup_failed", {
+      err,
+      projectId: input.projectId,
+    });
+    throw new AppError(
+      "project_vector_cleanup_failed",
+      502,
+      "Vector cleanup failed; project deletion remains pending. Retry deletion.",
+      err,
+    );
+  }
+
+  try {
+    await purgeProjectRetrievalCache(input.projectId);
+  } catch (err) {
+    log.error("project_cache_cleanup_failed", {
+      err,
+      projectId: input.projectId,
+    });
+    throw new AppError(
+      "project_cache_cleanup_failed",
+      502,
+      "Cache cleanup failed; project deletion remains pending. Retry deletion.",
+      err,
+    );
+  }
+
+  await hardDeleteProjectForUser(input);
+}

--- a/src/lib/projects/project-lifecycle-lease.server.test.ts
+++ b/src/lib/projects/project-lifecycle-lease.server.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  execute: vi.fn(),
+  findFirst: vi.fn(),
+}));
+
+vi.mock("@/db/client", () => ({
+  getDb: () => ({
+    transaction: async (callback: (tx: unknown) => Promise<unknown>) =>
+      await callback({
+        execute: state.execute,
+        query: { projectsTable: { findFirst: state.findFirst } },
+      }),
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  state.execute.mockResolvedValue(undefined);
+  state.findFirst.mockResolvedValue({
+    ownerUserId: "user_1",
+    status: "active",
+  });
+});
+
+describe("withActiveProjectLease", () => {
+  it("runs a producer only after acquiring the project lifecycle lock", async () => {
+    const work = vi.fn().mockResolvedValue("committed");
+    const { withActiveProjectLease } = await import(
+      "@/lib/projects/project-lifecycle-lease.server"
+    );
+
+    await expect(
+      withActiveProjectLease({ projectId: "proj_1", userId: "user_1" }, work),
+    ).resolves.toBe("committed");
+    expect(state.execute).toHaveBeenCalledOnce();
+    expect(state.findFirst).toHaveBeenCalledOnce();
+    expect(work).toHaveBeenCalledOnce();
+  });
+
+  it("rejects archived and deletion-pending projects before producer work", async () => {
+    const work = vi.fn();
+    const { withActiveProjectLease } = await import(
+      "@/lib/projects/project-lifecycle-lease.server"
+    );
+
+    for (const status of ["archived", "deleting"]) {
+      state.findFirst.mockResolvedValueOnce({
+        ownerUserId: "user_1",
+        status,
+      });
+      await expect(
+        withActiveProjectLease({ projectId: "proj_1", userId: "user_1" }, work),
+      ).rejects.toMatchObject({ code: "project_not_active", status: 409 });
+    }
+    expect(work).not.toHaveBeenCalled();
+  });
+
+  it("never treats a missing or differently owned project as writable", async () => {
+    state.findFirst.mockResolvedValueOnce(undefined);
+    const work = vi.fn();
+    const { withActiveProjectLease } = await import(
+      "@/lib/projects/project-lifecycle-lease.server"
+    );
+
+    await expect(
+      withActiveProjectLease(
+        { projectId: "proj_1", userId: "another_user" },
+        work,
+      ),
+    ).rejects.toMatchObject({ code: "project_not_found", status: 404 });
+    expect(work).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/projects/project-lifecycle-lease.server.ts
+++ b/src/lib/projects/project-lifecycle-lease.server.ts
@@ -1,0 +1,60 @@
+import "server-only";
+
+import { and, eq, sql } from "drizzle-orm";
+
+import { type DbClient, getDb } from "@/db/client";
+import * as schema from "@/db/schema";
+import { AppError } from "@/lib/core/errors";
+import { maybeWrapDbNotMigrated } from "@/lib/db/postgres-errors";
+
+/**
+ * Run one resource-producing commit while holding the project's lifecycle lock.
+ *
+ * Deletion claims use the same transaction-scoped advisory lock. The project
+ * must still be active after the lock is acquired, so a producer either commits
+ * before deletion observes it or is rejected after deletion owns the fence.
+ *
+ * @param input - Project scope and optional exact authenticated owner.
+ * @param work - Resource-producing commit to run while the lease is held.
+ * @returns The producer result.
+ */
+export async function withActiveProjectLease<T>(
+  input: Readonly<{ projectId: string; userId?: string }>,
+  work: (db: DbClient) => Promise<T>,
+): Promise<T> {
+  const db = getDb();
+  try {
+    return await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`select pg_advisory_xact_lock(hashtextextended(${input.projectId}, 0))`,
+      );
+      const ownership = input.userId
+        ? and(
+            eq(schema.projectsTable.id, input.projectId),
+            eq(schema.projectsTable.ownerUserId, input.userId),
+          )
+        : eq(schema.projectsTable.id, input.projectId);
+      const project = await tx.query.projectsTable.findFirst({
+        columns: { ownerUserId: true, status: true },
+        where: ownership,
+      });
+      if (!project) {
+        throw new AppError("project_not_found", 404, "Project not found.");
+      }
+      if (project.status !== "active") {
+        throw new AppError(
+          "project_not_active",
+          409,
+          "Restore the project before starting new work.",
+        );
+      }
+      // A transaction exposes the same query-builder surface used by these
+      // producers. Passing it through prevents callbacks from requesting a
+      // second connection while the lifecycle lock owns the pool connection.
+      return await work(tx as unknown as DbClient);
+    });
+  } catch (err) {
+    if (err instanceof AppError) throw err;
+    throw maybeWrapDbNotMigrated(err);
+  }
+}

--- a/src/lib/repo/repo-indexer.server.test.ts
+++ b/src/lib/repo/repo-indexer.server.test.ts
@@ -4,6 +4,7 @@ const state = vi.hoisted(() => ({
   embedTexts: vi.fn(),
   vectorDelete: vi.fn(),
   vectorUpsert: vi.fn(),
+  withActiveProjectLease: vi.fn(),
 }));
 
 vi.mock("@/lib/ai/embeddings.server", () => ({
@@ -21,12 +22,19 @@ vi.mock("@/lib/upstash/vector.server", () => ({
     `project:${projectId}:repo:${repoId}`,
 }));
 
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: state.withActiveProjectLease,
+}));
+
 describe("indexRepoFromSandbox", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     state.embedTexts.mockImplementation(async (inputs: readonly string[]) => {
       return inputs.map(() => [0, 0, 0]);
     });
+    state.withActiveProjectLease.mockImplementation(
+      async (_input: unknown, work: () => Promise<unknown>) => await work(),
+    );
   });
 
   it("indexes bounded repo content and deletes by prefix", async () => {
@@ -100,6 +108,17 @@ describe("indexRepoFromSandbox", () => {
 
     expect(state.vectorDelete).toHaveBeenCalledWith({ prefix: "repo:repo_1:" });
     expect(state.vectorUpsert).toHaveBeenCalled();
+    expect(state.withActiveProjectLease).toHaveBeenCalledTimes(2);
+    expect(state.withActiveProjectLease).toHaveBeenNthCalledWith(
+      1,
+      { projectId: "proj_1" },
+      expect.any(Function),
+    );
+    expect(state.withActiveProjectLease).toHaveBeenNthCalledWith(
+      2,
+      { projectId: "proj_1" },
+      expect.any(Function),
+    );
 
     const upsertPayload = state.vectorUpsert.mock.calls[0]?.[0] as unknown[];
     expect(upsertPayload.length).toBeGreaterThan(0);

--- a/src/lib/repo/repo-indexer.server.ts
+++ b/src/lib/repo/repo-indexer.server.ts
@@ -6,6 +6,7 @@ import { embedTexts } from "@/lib/ai/embeddings.server";
 import { budgets } from "@/lib/config/budgets.server";
 import { AppError } from "@/lib/core/errors";
 import { sha256Hex } from "@/lib/core/sha256";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 import {
   getVectorIndex,
   projectRepoNamespace,
@@ -283,7 +284,9 @@ export async function indexRepoFromSandbox(
   const vector = getVectorIndex().namespace(namespace);
 
   // Delete existing repo index (latest-only replacement).
-  await vector.delete({ prefix });
+  await withActiveProjectLease({ projectId: input.projectId }, async () => {
+    await vector.delete({ prefix });
+  });
 
   let totalBytes = 0;
   let filesIndexed = 0;
@@ -317,26 +320,28 @@ export async function indexRepoFromSandbox(
       throw new AppError("embed_failed", 500, "Embedding batch size mismatch.");
     }
 
-    await vector.upsert(
-      pendingRecords.map((rec, idx) => {
-        const meta: VectorMetadata = {
-          commitSha,
-          path: rec.path,
-          projectId: input.projectId,
-          repoId: input.repoId,
-          snippet: rec.snippet,
-          type: "code",
-          ...(rec.language === undefined ? {} : { language: rec.language }),
-        };
+    const records = pendingRecords.map((rec, idx) => {
+      const meta: VectorMetadata = {
+        commitSha,
+        path: rec.path,
+        projectId: input.projectId,
+        repoId: input.repoId,
+        snippet: rec.snippet,
+        type: "code",
+        ...(rec.language === undefined ? {} : { language: rec.language }),
+      };
 
-        return {
-          data: pendingTexts[idx] ?? "",
-          id: rec.id,
-          metadata: meta,
-          vector: embeddings[idx] as number[],
-        };
-      }),
-    );
+      return {
+        data: pendingTexts[idx] ?? "",
+        id: rec.id,
+        metadata: meta,
+        vector: embeddings[idx] as number[],
+      };
+    });
+
+    await withActiveProjectLease({ projectId: input.projectId }, async () => {
+      await vector.upsert(records);
+    });
 
     pendingTexts.length = 0;
     pendingRecords.length = 0;

--- a/src/lib/runs/code-mode-start.server.test.ts
+++ b/src/lib/runs/code-mode-start.server.test.ts
@@ -25,7 +25,13 @@ function createEnsureDb(
     }>;
   }>,
 ) {
-  const lock = vi.fn().mockResolvedValue([{ id: input.projectId }]);
+  const lock = vi.fn().mockResolvedValue([
+    {
+      id: input.projectId,
+      ownerUserId: input.userId,
+      status: "active",
+    },
+  ]);
   const activeLimit = vi
     .fn()
     .mockResolvedValue(options?.activeId ? [{ id: options.activeId }] : []);
@@ -43,6 +49,7 @@ function createEnsureDb(
   });
   const values = vi.fn().mockResolvedValue(undefined);
   const tx = {
+    execute: vi.fn().mockResolvedValue(undefined),
     insert: vi.fn(() => ({ values })),
     query: {
       runsTable: {

--- a/src/lib/runs/code-mode-start.server.ts
+++ b/src/lib/runs/code-mode-start.server.ts
@@ -77,13 +77,27 @@ export async function ensureCodeModeRun(
   const db = getDb();
 
   await db.transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtextextended(${input.projectId}, 0))`,
+    );
     const [project] = await tx
-      .select({ id: schema.projectsTable.id })
+      .select({
+        id: schema.projectsTable.id,
+        ownerUserId: schema.projectsTable.ownerUserId,
+        status: schema.projectsTable.status,
+      })
       .from(schema.projectsTable)
       .where(eq(schema.projectsTable.id, input.projectId))
       .for("update");
-    if (!project) {
+    if (!project || project.ownerUserId !== input.userId) {
       throw new AppError("not_found", 404, "Project not found.");
+    }
+    if (project.status !== "active") {
+      throw new AppError(
+        "project_not_active",
+        409,
+        "Restore the project before starting new work.",
+      );
     }
 
     const existing = await tx.query.runsTable.findFirst({

--- a/src/lib/runs/code-mode.server.test.ts
+++ b/src/lib/runs/code-mode.server.test.ts
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
 vi.mock("workflow/api", () => ({ start: state.start }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getOwnedProjectByIdForUser: state.getProjectByIdForUser,
   getProjectByIdForUser: state.getProjectByIdForUser,
 }));
 
@@ -62,13 +63,15 @@ beforeEach(() => {
 
 describe("startProjectCodeMode", () => {
   it("throws not_found before creating a run when project is inaccessible", async () => {
-    state.getProjectByIdForUser.mockResolvedValueOnce(null);
+    state.ensureCodeModeRun.mockRejectedValueOnce(
+      Object.assign(new Error("Project not found."), { code: "not_found" }),
+    );
 
     await expect(startProjectCodeMode(startInput)).rejects.toMatchObject({
       code: "not_found",
     });
 
-    expect(state.ensureCodeModeRun).not.toHaveBeenCalled();
+    expect(state.ensureCodeModeRun).toHaveBeenCalledOnce();
     expect(state.start).not.toHaveBeenCalled();
   });
 

--- a/src/lib/runs/code-mode.server.ts
+++ b/src/lib/runs/code-mode.server.ts
@@ -2,7 +2,7 @@ import "server-only";
 
 import { start } from "workflow/api";
 import { AppError } from "@/lib/core/errors";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import { getOwnedProjectByIdForUser } from "@/lib/data/projects.server";
 import { getRunById, type RunDto } from "@/lib/data/runs.server";
 import {
   claimCodeModeWorkflow,
@@ -38,11 +38,6 @@ export async function startProjectCodeMode(
     runId: string;
   }>,
 ): Promise<RunDto> {
-  const project = await getProjectByIdForUser(input.projectId, input.userId);
-  if (!project) {
-    throw new AppError("not_found", 404, "Project not found.");
-  }
-
   await ensureCodeModeRun({
     budgets: input.budgets,
     networkAccess: input.networkAccess,
@@ -99,7 +94,7 @@ export async function getCodeModeRun(
     throw new AppError("not_found", 404, "Run not found.");
   }
 
-  const project = await getProjectByIdForUser(run.projectId, userId);
+  const project = await getOwnedProjectByIdForUser(run.projectId, userId);
   if (!project) {
     throw new AppError("forbidden", 403, "Forbidden.");
   }
@@ -123,7 +118,7 @@ export async function getActiveProjectCodeModeRun(
   projectId: string,
   userId: string,
 ): Promise<RunDto | null> {
-  const project = await getProjectByIdForUser(projectId, userId);
+  const project = await getOwnedProjectByIdForUser(projectId, userId);
   if (!project) {
     throw new AppError("not_found", 404, "Project not found.");
   }

--- a/src/lib/runs/project-run.server.test.ts
+++ b/src/lib/runs/project-run.server.test.ts
@@ -28,7 +28,15 @@ vi.mock("@/lib/core/log", () => ({
 }));
 
 vi.mock("@/lib/data/projects.server", () => ({
+  getOwnedProjectByIdForUser: state.getProjectByIdForUser,
   getProjectByIdForUser: state.getProjectByIdForUser,
+}));
+
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: async (
+    _input: unknown,
+    work: () => Promise<unknown>,
+  ) => await work(),
 }));
 
 vi.mock("@/lib/data/runs.server", () => ({

--- a/src/lib/runs/project-run.server.ts
+++ b/src/lib/runs/project-run.server.ts
@@ -3,7 +3,7 @@ import "server-only";
 import { getRun, start } from "workflow/api";
 import { AppError } from "@/lib/core/errors";
 import { log } from "@/lib/core/log";
-import { getProjectByIdForUser } from "@/lib/data/projects.server";
+import { getOwnedProjectByIdForUser } from "@/lib/data/projects.server";
 import {
   completeRunCancellation,
   createRun,
@@ -14,6 +14,7 @@ import {
   setRunWorkflowRunId,
   updateRunStatus,
 } from "@/lib/data/runs.server";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 import { cancelRunSandboxes } from "@/lib/sandbox/sandbox-cancellation.server";
 import { projectRun } from "@/workflows/runs/project-run.workflow";
 
@@ -51,16 +52,18 @@ export async function startProjectRun(
     metadata?: Record<string, unknown>;
   }>,
 ): Promise<RunDto> {
-  const project = await getProjectByIdForUser(input.projectId, input.userId);
-  if (!project) {
-    throw new AppError("not_found", 404, "Project not found.");
-  }
-
-  const run = await createRun({
-    kind: input.kind,
-    projectId: input.projectId,
-    ...(input.metadata != null ? { metadata: input.metadata } : {}),
-  });
+  const run = await withActiveProjectLease(
+    { projectId: input.projectId, userId: input.userId },
+    (db) =>
+      createRun(
+        {
+          kind: input.kind,
+          projectId: input.projectId,
+          ...(input.metadata != null ? { metadata: input.metadata } : {}),
+        },
+        db,
+      ),
+  );
 
   let workflowRunId: string | null = null;
   try {
@@ -158,7 +161,7 @@ export async function cancelProjectRun(
     throw new AppError("not_found", 404, "Run not found.");
   }
 
-  const project = await getProjectByIdForUser(run.projectId, userId);
+  const project = await getOwnedProjectByIdForUser(run.projectId, userId);
   if (!project) {
     throw new AppError("not_found", 404, "Run not found.");
   }

--- a/src/workflows/skills-registry/steps/install-project-skill-from-registry.step.test.ts
+++ b/src/workflows/skills-registry/steps/install-project-skill-from-registry.step.test.ts
@@ -7,6 +7,7 @@ const state = vi.hoisted(() => ({
   error: vi.fn(),
   findProjectSkillByNameUncached: vi.fn(),
   findProjectSkillByRegistryId: vi.fn(),
+  leaseDb: {},
   putProjectSkillBundleBlob: vi.fn(),
   resolveRegistrySkillFromRepoZip: vi.fn(),
   updateProjectSkillById: vi.fn(),
@@ -49,6 +50,13 @@ vi.mock("@/lib/skills-registry/skill-bundle-blob.server", () => ({
 vi.mock("@/lib/skills-registry/zip-skill-resolver.server", () => ({
   resolveRegistrySkillFromRepoZip: (...args: unknown[]) =>
     state.resolveRegistrySkillFromRepoZip(...args),
+}));
+
+vi.mock("@/lib/projects/project-lifecycle-lease.server", () => ({
+  withActiveProjectLease: async (
+    _input: unknown,
+    work: (db: unknown) => Promise<unknown>,
+  ) => await work(state.leaseDb),
 }));
 
 async function loadModule() {
@@ -147,6 +155,7 @@ describe("installProjectSkillFromRegistryStep", () => {
           name: "Find Skills",
           projectId: "proj_1",
         }),
+        state.leaseDb,
       );
     });
 

--- a/src/workflows/skills-registry/steps/install-project-skill-from-registry.step.ts
+++ b/src/workflows/skills-registry/steps/install-project-skill-from-registry.step.ts
@@ -18,6 +18,7 @@ import {
   upsertProjectSkill,
 } from "@/lib/data/project-skills.server";
 import { env } from "@/lib/env";
+import { withActiveProjectLease } from "@/lib/projects/project-lifecycle-lease.server";
 import { downloadGithubRepoZip } from "@/lib/skills-registry/github-archive.server";
 import { parseSkillsRegistrySkillId } from "@/lib/skills-registry/registry-id.server";
 import {
@@ -103,99 +104,107 @@ export async function installProjectSkillFromRegistryStep(
     throw new AppError("bad_request", 400, "Skill name too long.");
   }
 
-  let existing = await findProjectSkillByRegistryId(
-    parsedInput.data.projectId,
-    ref.id,
-  );
-  const collision = await findProjectSkillByNameUncached(
-    parsedInput.data.projectId,
-    resolvedNameTrimmed,
-  );
-  const collisionRegistryId = collision
-    ? (getProjectSkillRegistryRef(collision.metadata)?.id ?? null)
-    : null;
-  if (
-    collision &&
-    collision.id !== existing?.id &&
-    collisionRegistryId !== ref.id
-  ) {
-    throw new AppError("conflict", 409, "Skill name already exists.");
-  }
-  if (!existing && collisionRegistryId === ref.id) {
-    existing = collision;
-  }
+  return await withActiveProjectLease(
+    { projectId: parsedInput.data.projectId },
+    async (db) => {
+      let existing = await findProjectSkillByRegistryId(
+        parsedInput.data.projectId,
+        ref.id,
+        db,
+      );
+      const collision = await findProjectSkillByNameUncached(
+        parsedInput.data.projectId,
+        resolvedNameTrimmed,
+        db,
+      );
+      const collisionRegistryId = collision
+        ? (getProjectSkillRegistryRef(collision.metadata)?.id ?? null)
+        : null;
+      if (
+        collision &&
+        collision.id !== existing?.id &&
+        collisionRegistryId !== ref.id
+      ) {
+        throw new AppError("conflict", 409, "Skill name already exists.");
+      }
+      if (!existing && collisionRegistryId === ref.id) existing = collision;
 
-  const previousBundle = existing
-    ? getProjectSkillBundleRef(existing.metadata)
-    : null;
-
-  const blobPath = getProjectSkillBundleBlobPath({
-    projectId: parsedInput.data.projectId,
-    skillName: toSafeBlobSegment(ref.id, MAX_BLOB_SEGMENT_CHARS),
-  });
-
-  const bundleBlobPathname = await putProjectSkillBundleBlob({
-    blobPath,
-    bytes: resolved.bundle.bytes,
-  });
-
-  const metadata = {
-    bundle: {
-      blobPath: bundleBlobPathname,
-      fileCount: resolved.bundle.fileCount,
-      format: "zip-v1" as const,
-      sizeBytes: resolved.bundle.sizeBytes,
-    },
-    registry: {
-      id: ref.id,
-      skillId: ref.skillId,
-      source: ref.source,
-    },
-  } satisfies Record<string, unknown>;
-
-  const skill = existing
-    ? await updateProjectSkillById({
-        content: resolved.content,
-        description: resolved.description,
-        metadata,
-        name: resolvedNameTrimmed,
+      const previousBundle = existing
+        ? getProjectSkillBundleRef(existing.metadata)
+        : null;
+      const blobPath = getProjectSkillBundleBlobPath({
         projectId: parsedInput.data.projectId,
-        skillId: existing.id,
-      })
-    : await upsertProjectSkill({
-        content: resolved.content,
-        description: resolved.description,
-        metadata,
-        name: resolvedNameTrimmed,
-        projectId: parsedInput.data.projectId,
+        skillName: toSafeBlobSegment(ref.id, MAX_BLOB_SEGMENT_CHARS),
       });
-
-  if (
-    previousBundle?.blobPath &&
-    previousBundle.blobPath !== bundleBlobPathname
-  ) {
-    try {
-      await del(previousBundle.blobPath, { token: env.blob.readWriteToken });
-    } catch (error) {
-      // Best-effort cleanup: orphaned bundles are acceptable and can be
-      // garbage-collected separately if needed.
-      log.error("project_skill_bundle_delete_failed", {
-        err: error,
-        previousBlobPath: previousBundle.blobPath,
-        projectId: parsedInput.data.projectId,
-        registryId: ref.id,
-        skillName: resolvedNameTrimmed,
+      const bundleBlobPathname = await putProjectSkillBundleBlob({
+        blobPath,
+        bytes: resolved.bundle.bytes,
       });
-    }
-  }
+      const metadata = {
+        bundle: {
+          blobPath: bundleBlobPathname,
+          fileCount: resolved.bundle.fileCount,
+          format: "zip-v1" as const,
+          sizeBytes: resolved.bundle.sizeBytes,
+        },
+        registry: {
+          id: ref.id,
+          skillId: ref.skillId,
+          source: ref.source,
+        },
+      } satisfies Record<string, unknown>;
 
-  return {
-    skill: {
-      content: skill.content,
-      description: skill.description,
-      id: skill.id,
-      name: skill.name,
-      updatedAt: skill.updatedAt,
+      const skill = existing
+        ? await updateProjectSkillById(
+            {
+              content: resolved.content,
+              description: resolved.description,
+              metadata,
+              name: resolvedNameTrimmed,
+              projectId: parsedInput.data.projectId,
+              skillId: existing.id,
+            },
+            db,
+          )
+        : await upsertProjectSkill(
+            {
+              content: resolved.content,
+              description: resolved.description,
+              metadata,
+              name: resolvedNameTrimmed,
+              projectId: parsedInput.data.projectId,
+            },
+            db,
+          );
+
+      if (
+        previousBundle?.blobPath &&
+        previousBundle.blobPath !== bundleBlobPathname
+      ) {
+        try {
+          await del(previousBundle.blobPath, {
+            token: env.blob.readWriteToken,
+          });
+        } catch (error) {
+          log.error("project_skill_bundle_delete_failed", {
+            err: error,
+            previousBlobPath: previousBundle.blobPath,
+            projectId: parsedInput.data.projectId,
+            registryId: ref.id,
+            skillName: resolvedNameTrimmed,
+          });
+        }
+      }
+
+      return {
+        skill: {
+          content: skill.content,
+          description: skill.description,
+          id: skill.id,
+          name: skill.name,
+          updatedAt: skill.updatedAt,
+        },
+      };
     },
-  };
+  );
 }


### PR DESCRIPTION
## Summary

- add exact-owner project rename, archive, restore, and typed-confirm deletion UX
- fence every project resource producer with a shared lifecycle lock and make deletion retry-safe across Blob, Vector, Redis, and relational cleanup
- persist short-lived client-upload grants so finite Blob callbacks cannot orphan late uploads
- retain non-secret deployment and infrastructure provenance as detached operational tombstones
- align lifecycle, provider-role, migration, accessibility, and manual preview-E2E documentation

## Verification

- `bun run ci`
- `bun run test:a11y` (24 passed)
- `git diff --check`
- independent adversarial backend and UI/docs reviews: no unresolved Critical or High findings

## Manual release gate

A configured preview still needs the provider-faked lifecycle browser flow tracked in #56. The repository intentionally contains no placeholder credentials or local Vercel link state.